### PR TITLE
RTree links wrong shared object on linux

### DIFF
--- a/rtree/core.py
+++ b/rtree/core.py
@@ -102,9 +102,7 @@ if os.name == 'nt':
 
 elif os.name == 'posix':
     platform = os.uname()[0]
-    lib_name = 'libspatialindex_c.so'
-    if platform == 'Darwin':
-        lib_name = 'libspatialindex_c.dylib'
+    lib_name = find_library('spatialindex_c')
     rt = ctypes.CDLL(lib_name)
 else:
     raise RTreeError('Unsupported OS "%s"' % os.name)


### PR DESCRIPTION
RTree depends on libspatialindex_c.so, which is only development symlink to actual library and should be used only during compile time. This requires that dev packages of libspatialindex are also installed for RTree to work. Bugfix should be simple:

Following line: https://github.com/Toblerity/rtree/blob/master/rtree/core.py#L105
_lib_name = 'libspatialindex_c.so'_
should be replaced with
_lib_name = ctypes.find_library('spatialindex_c')_
which then selects correct name (libspatialindex_c.so.1), at least on linux.
