### PR TITLE
A fix for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - pip install -e .
 
 script:
-  - py.test tests/test_doctests.py
+  - py.test tests/test_doctests.py tests/test_index.py

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -11,8 +11,12 @@ except ImportError:
     import pickle
 
 import sys
-if 2==(sys.version_info[0]):
-  range=xrange
+if sys.version_info[0] == 2:
+    range = xrange
+    string_types = basestring
+elif sys.version_info[0] == 3:
+    string_types = str
+
 RT_Memory = 0
 RT_Disk = 1
 RT_Custom = 2
@@ -172,7 +176,7 @@ class Index(object):
         basename = None
         storage = None
         if args:
-            if isinstance(args[0], str) or isinstance(args[0], bytes) or isinstance(args[0], unicode):
+            if isinstance(args[0], string_types) or isinstance(args[0], bytes):
                 # they sent in a filename
                 basename = args[0]
                 # they sent in a filename, stream

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,19 @@
+from rtree import index
+
+from .data import boxes15
+
+def boxes15_stream(interleaved=True):
+   for i, (minx, miny, maxx, maxy) in enumerate(boxes15):
+       if interleaved:
+           yield (i, (minx, miny, maxx, maxy), 42)
+       else:
+           yield (i, (minx, maxx, miny, maxy), 42)
+
+
+def test_rtree_constructor_stream_input():
+    p = index.Property()
+    sindex = index.Rtree(boxes15_stream(), properties=p)
+
+    bounds = (0, 0, 60, 60)
+    hits = list(sindex.intersection(bounds))
+    assert sorted(hits) == [0, 4, 16, 27, 35, 40, 47, 50, 76, 80]


### PR DESCRIPTION
Looks like 0.81 broke Python 3 compatibility in https://github.com/Toblerity/rtree/commit/96b2617b4e45cf3fd920932615a5fe4bef0d1702#diff-d81684ea57a4576f3ff7720dd43a08d1L175.

This commit fixes the unicode check by introducing `string_types` like in [six](https://pypi.python.org/pypi/six) for 2/3 compatibility.

Also one of the tests should have caught the bug but the tests don't actually run. Only the `test_suite()` function is called without ever running the underlying tests - so it's really testing that the suite just gets setup correctly.

I started a new module that pulls the relevant test case from the `index.txt` doctest as a start to move away from doctests here. If you think that's too much I can just commit the `index.py` fix.
