### PR TITLE
Fix build status link to point to Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rtree
 =====
 
-![](https://travis-ci.org/Toblerity/rtree.svg)
+[![Build Status](https://travis-ci.org/Toblerity/rtree.svg)](https://travis-ci.org/Toblerity/rtree)
 
 Python bindings for libspatialindex 1.7+.
 


### PR DESCRIPTION
It seems like pretty common practice to link to the actual builds, and is nice to have.