### PR TITLE
Add pickling support (fixes #42)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - pip install -e .
 
 script:
-  - py.test tests/test_doctests.py tests/test_index.py
+  - py.test tests/test_doctests.py tests/test_index.py tests/test_pickle.py

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,18 @@
+import unittest
+
 from rtree import index
 
 from .data import boxes15
+
+class IndexTests(unittest.TestCase):
+
+    def test_stream_input(self):
+        p = index.Property()
+        sindex = index.Index(boxes15_stream(), properties=p)
+        bounds = (0, 0, 60, 60)
+        hits = sindex.intersection(bounds)
+        self.assertEqual(sorted(hits), [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
+
 
 def boxes15_stream(interleaved=True):
    for i, (minx, miny, maxx, maxy) in enumerate(boxes15):
@@ -8,12 +20,3 @@ def boxes15_stream(interleaved=True):
            yield (i, (minx, miny, maxx, maxy), 42)
        else:
            yield (i, (minx, maxx, miny, maxy), 42)
-
-
-def test_rtree_constructor_stream_input():
-    p = index.Property()
-    sindex = index.Rtree(boxes15_stream(), properties=p)
-
-    bounds = (0, 0, 60, 60)
-    hits = list(sindex.intersection(bounds))
-    assert sorted(hits) == [0, 4, 16, 27, 35, 40, 47, 50, 76, 80]

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,19 @@
+import pickle
+import unittest
+import rtree.index
+
+class TestPickling(unittest.TestCase):
+
+    def test_index(self):
+        idx = rtree.index.Index()
+        unpickled = pickle.loads(pickle.dumps(idx))
+        self.assertNotEquals(idx.handle, unpickled.handle)
+        self.assertEquals(idx.properties.as_dict(),
+            unpickled.properties.as_dict())
+        self.assertEquals(idx.interleaved, unpickled.interleaved)
+
+    def test_property(self):
+        p = rtree.index.Property()
+        unpickled = pickle.loads(pickle.dumps(p))
+        self.assertNotEquals(p.handle, unpickled.handle)
+        self.assertEquals(p.as_dict(), unpickled.as_dict())


### PR DESCRIPTION
Make Index and Property objects pickleable. This fixes issue #42 .

Also, move ctypes handle objects into their own wrapper objects. The lifetime of the underlying C object is tied to the wrapper. This makes it easier to pass handles without worrying about ownership.