### PR TITLE
Apply formatting for PEP 8 code style

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.txt
+include README.md
 include MANIFEST.in
 include DEPENDENCIES.txt
 include FAQ.txt

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -1,68 +1,74 @@
-import atexit, os, re, sys
+import os
 import ctypes
 from ctypes.util import find_library
 
-import ctypes
 
 class RTreeError(Exception):
     "RTree exception, indicates a RTree-related error."
     pass
 
+
 def check_return(result, func, cargs):
     "Error checking for Error calls"
     if result != 0:
-        msg = 'LASError in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg() )
+        msg = 'LASError in "%s": %s' % \
+            (func.__name__, rt.Error_GetLastErrorMsg())
         rt.Error_Reset()
         raise RTreeError(msg)
     return True
 
+
 def check_void(result, func, cargs):
     "Error checking for void* returns"
     if not bool(result):
-        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg() )
+        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg())
         rt.Error_Reset()
         raise RTreeError(msg)
     return result
 
+
 def check_void_done(result, func, cargs):
     "Error checking for void* returns that might be empty with no error"
     if rt.Error_GetErrorCount():
-        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg() )
+        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg())
         rt.Error_Reset()
         raise RTreeError(msg)
-        
     return result
+
 
 def check_value(result, func, cargs):
     "Error checking proper value returns"
     count = rt.Error_GetErrorCount()
     if count != 0:
-        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg() )
+        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg())
         rt.Error_Reset()
         raise RTreeError(msg)
     return result
+
 
 def check_value_free(result, func, cargs):
     "Error checking proper value returns"
     count = rt.Error_GetErrorCount()
     if count != 0:
-        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg() )
+        msg = 'Error in "%s": %s' % (func.__name__, rt.Error_GetLastErrorMsg())
         rt.Error_Reset()
         raise RTreeError(msg)
     return result
+
 
 def free_returned_char_p(result, func, cargs):
     retvalue = ctypes.string_at(result)
     p = ctypes.cast(result, ctypes.POINTER(ctypes.c_void_p))
     rt.Index_Free(p)
     return retvalue
-    
+
+
 def free_error_msg_ptr(result, func, cargs):
     retvalue = ctypes.string_at(result)
     p = ctypes.cast(result, ctypes.POINTER(ctypes.c_void_p))
     rt.Index_Free(p)
     return retvalue
-    
+
 
 if os.name == 'nt':
 
@@ -77,7 +83,7 @@ if os.name == 'nt':
             dllpaths = (os.path.abspath(os.path.dirname(__file__)),
                         ) + dllpaths
         except NameError:
-            pass # no __file__ attribute on PyPy and some frozen distributions
+            pass  # no __file__ attribute on PyPy and some frozen distributions
         for path in dllpaths:
             if path:
                 # temporarily add the path to the PATH environment variable
@@ -120,7 +126,7 @@ rt.Error_GetLastErrorMethod.restype = ctypes.POINTER(ctypes.c_char)
 rt.Error_GetLastErrorMethod.errcheck = free_returned_char_p
 
 rt.Error_GetErrorCount.argtypes = []
-rt.Error_GetErrorCount.restype=ctypes.c_int
+rt.Error_GetErrorCount.restype = ctypes.c_int
 
 rt.Error_Reset.argtypes = []
 rt.Error_Reset.restype = None
@@ -129,7 +135,7 @@ rt.Index_Create.argtypes = [ctypes.c_void_p]
 rt.Index_Create.restype = ctypes.c_void_p
 rt.Index_Create.errcheck = check_void
 
-NEXTFUNC = ctypes.CFUNCTYPE(ctypes.c_int, 
+NEXTFUNC = ctypes.CFUNCTYPE(ctypes.c_int,
                             ctypes.POINTER(ctypes.c_int64),
                             ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
                             ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
@@ -137,7 +143,7 @@ NEXTFUNC = ctypes.CFUNCTYPE(ctypes.c_int,
                             ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
                             ctypes.POINTER(ctypes.c_size_t))
 
-rt.Index_CreateWithStream.argtypes = [ctypes.c_void_p, NEXTFUNC] 
+rt.Index_CreateWithStream.argtypes = [ctypes.c_void_p, NEXTFUNC]
 rt.Index_CreateWithStream.restype = ctypes.c_void_p
 rt.Index_CreateWithStream.errcheck = check_void
 
@@ -149,28 +155,28 @@ rt.Index_GetProperties.argtypes = [ctypes.c_void_p]
 rt.Index_GetProperties.restype = ctypes.c_void_p
 rt.Index_GetProperties.errcheck = check_void
 
-rt.Index_DeleteData.argtypes = [ctypes.c_void_p, 
-                                ctypes.c_int64, 
-                                ctypes.POINTER(ctypes.c_double), 
-                                ctypes.POINTER(ctypes.c_double), 
+rt.Index_DeleteData.argtypes = [ctypes.c_void_p,
+                                ctypes.c_int64,
+                                ctypes.POINTER(ctypes.c_double),
+                                ctypes.POINTER(ctypes.c_double),
                                 ctypes.c_uint32]
 rt.Index_DeleteData.restype = ctypes.c_int
 rt.Index_DeleteData.errcheck = check_return
 
-rt.Index_InsertData.argtypes = [ctypes.c_void_p, 
-                                ctypes.c_int64, 
-                                ctypes.POINTER(ctypes.c_double), 
-                                ctypes.POINTER(ctypes.c_double), 
-                                ctypes.c_uint32, 
-                                ctypes.POINTER(ctypes.c_ubyte), 
+rt.Index_InsertData.argtypes = [ctypes.c_void_p,
+                                ctypes.c_int64,
+                                ctypes.POINTER(ctypes.c_double),
+                                ctypes.POINTER(ctypes.c_double),
+                                ctypes.c_uint32,
+                                ctypes.POINTER(ctypes.c_ubyte),
                                 ctypes.c_uint32]
 rt.Index_InsertData.restype = ctypes.c_int
 rt.Index_InsertData.errcheck = check_return
 
-rt.Index_GetBounds.argtypes = [ ctypes.c_void_p,
-                                ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                                ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                                ctypes.POINTER(ctypes.c_uint32)]
+rt.Index_GetBounds.argtypes = [ctypes.c_void_p,
+                               ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+                               ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+                               ctypes.POINTER(ctypes.c_uint32)]
 rt.Index_GetBounds.restype = ctypes.c_int
 rt.Index_GetBounds.errcheck = check_value
 
@@ -179,59 +185,67 @@ rt.Index_IsValid.restype = ctypes.c_int
 rt.Index_IsValid.errcheck = check_value
 
 rt.Index_Intersects_obj.argtypes = [ctypes.c_void_p,
-                                    ctypes.POINTER(ctypes.c_double), 
-                                    ctypes.POINTER(ctypes.c_double), 
-                                    ctypes.c_uint32, 
-                                    ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+                                    ctypes.POINTER(ctypes.c_double),
+                                    ctypes.POINTER(ctypes.c_double),
+                                    ctypes.c_uint32,
+                                    ctypes.POINTER(
+                                        ctypes.POINTER(ctypes.c_void_p)),
                                     ctypes.POINTER(ctypes.c_uint64)]
 rt.Index_Intersects_obj.restype = ctypes.c_int
 rt.Index_Intersects_obj.errcheck = check_return
 
 rt.Index_Intersects_id.argtypes = [ctypes.c_void_p,
-                                    ctypes.POINTER(ctypes.c_double), 
-                                    ctypes.POINTER(ctypes.c_double), 
-                                    ctypes.c_uint32, 
-                                    ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
-                                    ctypes.POINTER(ctypes.c_uint64)]
+                                   ctypes.POINTER(ctypes.c_double),
+                                   ctypes.POINTER(ctypes.c_double),
+                                   ctypes.c_uint32,
+                                   ctypes.POINTER(
+                                       ctypes.POINTER(ctypes.c_int64)),
+                                   ctypes.POINTER(ctypes.c_uint64)]
 rt.Index_Intersects_id.restype = ctypes.c_int
 rt.Index_Intersects_id.errcheck = check_return
 
-rt.Index_Intersects_count.argtypes = [  ctypes.c_void_p,
-                                        ctypes.POINTER(ctypes.c_double),
-                                        ctypes.POINTER(ctypes.c_double),
-                                        ctypes.c_uint32,
-                                        ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_Intersects_count.argtypes = [ctypes.c_void_p,
+                                      ctypes.POINTER(ctypes.c_double),
+                                      ctypes.POINTER(ctypes.c_double),
+                                      ctypes.c_uint32,
+                                      ctypes.POINTER(ctypes.c_uint64)]
 
-rt.Index_NearestNeighbors_obj.argtypes = [  ctypes.c_void_p,
-                                            ctypes.POINTER(ctypes.c_double), 
-                                            ctypes.POINTER(ctypes.c_double), 
-                                            ctypes.c_uint32, 
-                                            ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
-                                            ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_NearestNeighbors_obj.argtypes = [ctypes.c_void_p,
+                                          ctypes.POINTER(ctypes.c_double),
+                                          ctypes.POINTER(ctypes.c_double),
+                                          ctypes.c_uint32,
+                                          ctypes.POINTER(
+                                              ctypes.POINTER(ctypes.c_void_p)),
+                                          ctypes.POINTER(ctypes.c_uint64)]
 rt.Index_NearestNeighbors_obj.restype = ctypes.c_int
 rt.Index_NearestNeighbors_obj.errcheck = check_return
 
-rt.Index_NearestNeighbors_id.argtypes = [  ctypes.c_void_p,
-                                            ctypes.POINTER(ctypes.c_double), 
-                                            ctypes.POINTER(ctypes.c_double), 
-                                            ctypes.c_uint32, 
-                                            ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
-                                            ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_NearestNeighbors_id.argtypes = [ctypes.c_void_p,
+                                         ctypes.POINTER(ctypes.c_double),
+                                         ctypes.POINTER(ctypes.c_double),
+                                         ctypes.c_uint32,
+                                         ctypes.POINTER(
+                                             ctypes.POINTER(ctypes.c_int64)),
+                                         ctypes.POINTER(ctypes.c_uint64)]
 rt.Index_NearestNeighbors_id.restype = ctypes.c_int
 rt.Index_NearestNeighbors_id.errcheck = check_return
 
-rt.Index_GetLeaves.argtypes = [ ctypes.c_void_p,
-                                ctypes.POINTER(ctypes.c_uint32), 
-                                ctypes.POINTER(ctypes.POINTER(ctypes.c_uint32)), 
-                                ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)), 
-                                ctypes.POINTER(ctypes.POINTER(ctypes.POINTER(ctypes.c_int64))),
-                                ctypes.POINTER(ctypes.POINTER(ctypes.POINTER(ctypes.c_double))),
-                                ctypes.POINTER(ctypes.POINTER(ctypes.POINTER(ctypes.c_double))),
-                                ctypes.POINTER(ctypes.c_uint32)]
+rt.Index_GetLeaves.argtypes = [ctypes.c_void_p,
+                               ctypes.POINTER(ctypes.c_uint32),
+                               ctypes.POINTER(ctypes.POINTER(ctypes.c_uint32)),
+                               ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
+                               ctypes.POINTER(ctypes.POINTER(
+                                   ctypes.POINTER(ctypes.c_int64))),
+                               ctypes.POINTER(ctypes.POINTER(
+                                   ctypes.POINTER(ctypes.c_double))),
+                               ctypes.POINTER(ctypes.POINTER(
+                                   ctypes.POINTER(ctypes.c_double))),
+                               ctypes.POINTER(ctypes.c_uint32)]
 rt.Index_GetLeaves.restype = ctypes.c_int
 rt.Index_GetLeaves.errcheck = check_return
 
-rt.Index_DestroyObjResults.argtypes = [ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)), ctypes.c_uint32]
+rt.Index_DestroyObjResults.argtypes = \
+    [ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)), ctypes.c_uint32]
 rt.Index_DestroyObjResults.restype = None
 rt.Index_DestroyObjResults.errcheck = check_void_done
 
@@ -246,16 +260,19 @@ rt.IndexItem_Destroy.argtypes = [ctypes.c_void_p]
 rt.IndexItem_Destroy.restype = None
 rt.IndexItem_Destroy.errcheck = check_void_done
 
-rt.IndexItem_GetData.argtypes = [   ctypes.c_void_p, 
-                                    ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)), 
-                                    ctypes.POINTER(ctypes.c_uint64)]
+rt.IndexItem_GetData.argtypes = [ctypes.c_void_p,
+                                 ctypes.POINTER(
+                                     ctypes.POINTER(ctypes.c_ubyte)),
+                                 ctypes.POINTER(ctypes.c_uint64)]
 rt.IndexItem_GetData.restype = ctypes.c_int
 rt.IndexItem_GetData.errcheck = check_value
 
-rt.IndexItem_GetBounds.argtypes = [ ctypes.c_void_p,
-                                    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                                    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                                    ctypes.POINTER(ctypes.c_uint32)]
+rt.IndexItem_GetBounds.argtypes = [ctypes.c_void_p,
+                                   ctypes.POINTER(
+                                       ctypes.POINTER(ctypes.c_double)),
+                                   ctypes.POINTER(
+                                       ctypes.POINTER(ctypes.c_double)),
+                                   ctypes.POINTER(ctypes.c_uint32)]
 rt.IndexItem_GetBounds.restype = ctypes.c_int
 rt.IndexItem_GetBounds.errcheck = check_value
 
@@ -327,7 +344,8 @@ rt.IndexProperty_GetPagesize.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetPagesize.restype = ctypes.c_int
 rt.IndexProperty_GetPagesize.errcheck = check_value
 
-rt.IndexProperty_SetLeafPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetLeafPoolCapacity.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetLeafPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetLeafPoolCapacity.errcheck = check_return
 
@@ -335,7 +353,8 @@ rt.IndexProperty_GetLeafPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetLeafPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetLeafPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetIndexPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetIndexPoolCapacity.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetIndexPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetIndexPoolCapacity.errcheck = check_return
 
@@ -343,7 +362,8 @@ rt.IndexProperty_GetIndexPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetIndexPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetIndexPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetRegionPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetRegionPoolCapacity.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetRegionPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetRegionPoolCapacity.errcheck = check_return
 
@@ -351,7 +371,8 @@ rt.IndexProperty_GetRegionPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetRegionPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetRegionPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetPointPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetPointPoolCapacity.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetPointPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetPointPoolCapacity.errcheck = check_return
 
@@ -359,7 +380,8 @@ rt.IndexProperty_GetPointPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetPointPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetPointPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetBufferingCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetBufferingCapacity.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetBufferingCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetBufferingCapacity.errcheck = check_return
 
@@ -367,7 +389,8 @@ rt.IndexProperty_GetBufferingCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetBufferingCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetBufferingCapacity.errcheck = check_value
 
-rt.IndexProperty_SetEnsureTightMBRs.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetEnsureTightMBRs.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetEnsureTightMBRs.restype = ctypes.c_int
 rt.IndexProperty_SetEnsureTightMBRs.errcheck = check_return
 
@@ -383,7 +406,8 @@ rt.IndexProperty_GetOverwrite.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetOverwrite.restype = ctypes.c_int
 rt.IndexProperty_GetOverwrite.errcheck = check_value
 
-rt.IndexProperty_SetNearMinimumOverlapFactor.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetNearMinimumOverlapFactor.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetNearMinimumOverlapFactor.restype = ctypes.c_int
 rt.IndexProperty_SetNearMinimumOverlapFactor.errcheck = check_return
 
@@ -407,7 +431,8 @@ rt.IndexProperty_GetFillFactor.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFillFactor.restype = ctypes.c_double
 rt.IndexProperty_GetFillFactor.errcheck = check_value
 
-rt.IndexProperty_SetSplitDistributionFactor.argtypes = [ctypes.c_void_p, ctypes.c_double]
+rt.IndexProperty_SetSplitDistributionFactor.argtypes = \
+    [ctypes.c_void_p, ctypes.c_double]
 rt.IndexProperty_SetSplitDistributionFactor.restype = ctypes.c_int
 rt.IndexProperty_SetSplitDistributionFactor.errcheck = check_return
 
@@ -423,7 +448,8 @@ rt.IndexProperty_GetTPRHorizon.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetTPRHorizon.restype = ctypes.c_double
 rt.IndexProperty_GetTPRHorizon.errcheck = check_value
 
-rt.IndexProperty_SetReinsertFactor.argtypes = [ctypes.c_void_p, ctypes.c_double]
+rt.IndexProperty_SetReinsertFactor.argtypes = \
+    [ctypes.c_void_p, ctypes.c_double]
 rt.IndexProperty_SetReinsertFactor.restype = ctypes.c_int
 rt.IndexProperty_SetReinsertFactor.errcheck = check_return
 
@@ -439,23 +465,28 @@ rt.IndexProperty_GetFileName.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFileName.errcheck = free_returned_char_p
 rt.IndexProperty_GetFileName.restype = ctypes.POINTER(ctypes.c_char)
 
-rt.IndexProperty_SetFileNameExtensionDat.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+rt.IndexProperty_SetFileNameExtensionDat.argtypes = \
+    [ctypes.c_void_p, ctypes.c_char_p]
 rt.IndexProperty_SetFileNameExtensionDat.restype = ctypes.c_int
 rt.IndexProperty_SetFileNameExtensionDat.errcheck = check_return
 
 rt.IndexProperty_GetFileNameExtensionDat.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFileNameExtensionDat.errcheck = free_returned_char_p
-rt.IndexProperty_GetFileNameExtensionDat.restype = ctypes.POINTER(ctypes.c_char)
+rt.IndexProperty_GetFileNameExtensionDat.restype = \
+    ctypes.POINTER(ctypes.c_char)
 
-rt.IndexProperty_SetFileNameExtensionIdx.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+rt.IndexProperty_SetFileNameExtensionIdx.argtypes = \
+    [ctypes.c_void_p, ctypes.c_char_p]
 rt.IndexProperty_SetFileNameExtensionIdx.restype = ctypes.c_int
 rt.IndexProperty_SetFileNameExtensionIdx.errcheck = check_return
 
 rt.IndexProperty_GetFileNameExtensionIdx.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFileNameExtensionIdx.errcheck = free_returned_char_p
-rt.IndexProperty_GetFileNameExtensionIdx.restype = ctypes.POINTER(ctypes.c_char)
+rt.IndexProperty_GetFileNameExtensionIdx.restype = \
+    ctypes.POINTER(ctypes.c_char)
 
-rt.IndexProperty_SetCustomStorageCallbacksSize.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetCustomStorageCallbacksSize.argtypes = \
+    [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetCustomStorageCallbacksSize.restype = ctypes.c_int
 rt.IndexProperty_SetCustomStorageCallbacksSize.errcheck = check_return
 
@@ -463,7 +494,8 @@ rt.IndexProperty_GetCustomStorageCallbacksSize.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetCustomStorageCallbacksSize.restype = ctypes.c_uint32
 rt.IndexProperty_GetCustomStorageCallbacksSize.errcheck = check_value
 
-rt.IndexProperty_SetCustomStorageCallbacks.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+rt.IndexProperty_SetCustomStorageCallbacks.argtypes = \
+    [ctypes.c_void_p, ctypes.c_void_p]
 rt.IndexProperty_SetCustomStorageCallbacks.restype = ctypes.c_int
 rt.IndexProperty_SetCustomStorageCallbacks.errcheck = check_return
 

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -5,7 +5,7 @@ from rtree import index
 import ogr
 
 
-def quick_create_layer_def( lyr, field_list):
+def quick_create_layer_def(lyr, field_list):
     # Each field is a tuple of (name, type, width, precision)
     # Any of type, width and precision can be skipped.  Default type is string.
 
@@ -16,66 +16,71 @@ def quick_create_layer_def( lyr, field_list):
         else:
             type = ogr.OFTString
 
-        field_defn = ogr.FieldDefn( name, type )
-        
+        field_defn = ogr.FieldDefn(name, type)
+
         if len(field) > 2:
-            field_defn.SetWidth( int(field[2]) )
+            field_defn.SetWidth(int(field[2]))
 
         if len(field) > 3:
-            field_defn.SetPrecision( int(field[3]) )
+            field_defn.SetPrecision(int(field[3]))
 
-        lyr.CreateField( field_defn )
+        lyr.CreateField(field_defn)
 
         field_defn.Destroy()
-        
+
 
 import sys
 
 shape_drv = ogr.GetDriverByName('ESRI Shapefile')
 
 shapefile_name = sys.argv[1].split('.')[0]
-shape_ds = shape_drv.CreateDataSource( shapefile_name)
-leaf_block_lyr = shape_ds.CreateLayer( 'leaf', geom_type = ogr.wkbPolygon )
-point_block_lyr = shape_ds.CreateLayer( 'point', geom_type = ogr.wkbPolygon )
-point_lyr = shape_ds.CreateLayer( 'points', geom_type = ogr.wkbPoint )
+shape_ds = shape_drv.CreateDataSource(shapefile_name)
+leaf_block_lyr = shape_ds.CreateLayer('leaf', geom_type=ogr.wkbPolygon)
+point_block_lyr = shape_ds.CreateLayer('point', geom_type=ogr.wkbPolygon)
+point_lyr = shape_ds.CreateLayer('points', geom_type=ogr.wkbPoint)
 
-quick_create_layer_def( leaf_block_lyr,
-                                    [ 
-                                      ('BLK_ID', ogr.OFTInteger),
-                                      ('COUNT', ogr.OFTInteger),
-                                      ] )
+quick_create_layer_def(
+    leaf_block_lyr,
+    [
+        ('BLK_ID', ogr.OFTInteger),
+        ('COUNT', ogr.OFTInteger),
+    ])
 
-quick_create_layer_def( point_block_lyr,
-                                    [ 
-                                      ('BLK_ID', ogr.OFTInteger),
-                                      ('COUNT', ogr.OFTInteger),
-                                      ] )
-                                      
-quick_create_layer_def( point_lyr,
-                                    [ 
-                                      ('ID', ogr.OFTInteger),
-                                      ('BLK_ID', ogr.OFTInteger),
-                                      ] )
+quick_create_layer_def(
+    point_block_lyr,
+    [
+        ('BLK_ID', ogr.OFTInteger),
+        ('COUNT', ogr.OFTInteger),
+    ])
+
+quick_create_layer_def(
+    point_lyr,
+    [
+        ('ID', ogr.OFTInteger),
+        ('BLK_ID', ogr.OFTInteger),
+    ])
 
 p = index.Property()
 p.filename = sys.argv[1]
-p.overwrite=False
+p.overwrite = False
 
 p.storage = index.RT_Disk
 idx = index.Index(sys.argv[1])
 
-
 leaves = idx.leaves()
-#leaves[0] == (0L, [2L, 92L, 51L, 55L, 26L], [-132.41727847799999, -96.717721818399994, -132.41727847799999, -96.717721818399994])
+# leaves[0] == (0L, [2L, 92L, 51L, 55L, 26L], [-132.41727847799999,
+# -96.717721818399994, -132.41727847799999, -96.717721818399994])
 
 from liblas import file
 f = file.File(sys.argv[1])
 
+
 def area(minx, miny, maxx, maxy):
     width = abs(maxx - minx)
     height = abs(maxy - miny)
-    
+
     return width*height
+
 
 def get_bounds(leaf_ids, lasfile, block_id):
     # read the first point and set the bounds to that
@@ -83,9 +88,9 @@ def get_bounds(leaf_ids, lasfile, block_id):
     p = lasfile.read(leaf_ids[0])
     minx, maxx = p.x, p.x
     miny, maxy = p.y, p.y
-    
-    print len(leaf_ids)
-    print leaf_ids[0:10]
+
+    print(len(leaf_ids))
+    print(leaf_ids[0:10])
 
     for p_id in leaf_ids:
         p = lasfile.read(p_id)
@@ -93,68 +98,71 @@ def get_bounds(leaf_ids, lasfile, block_id):
         maxx = max(maxx, p.x)
         miny = min(miny, p.y)
         maxy = max(maxy, p.y)
-        feature = ogr.Feature( feature_def = point_lyr.GetLayerDefn() )
-        g = ogr.CreateGeometryFromWkt('POINT (%.8f %.8f)'%(p.x, p.y))
+        feature = ogr.Feature(feature_def=point_lyr.GetLayerDefn())
+        g = ogr.CreateGeometryFromWkt('POINT (%.8f %.8f)' % (p.x, p.y))
         feature.SetGeometry(g)
-        feature.SetField('ID',p_id)
-        feature.SetField('BLK_ID',block_id)
+        feature.SetField('ID', p_id)
+        feature.SetField('BLK_ID', block_id)
         result = point_lyr.CreateFeature(feature)
-    
+        del result
+
     return (minx, miny, maxx, maxy)
 
+
 def make_poly(minx, miny, maxx, maxy):
-    wkt = 'POLYGON ((%.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f))' % (minx, miny, maxx, miny, maxx, maxy, minx, maxy, minx, miny)
+    wkt = 'POLYGON ((%.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f))'\
+        % (minx, miny, maxx, miny, maxx, maxy, minx, maxy, minx, miny)
     shp = ogr.CreateGeometryFromWkt(wkt)
     return shp
 
+
 def make_feature(lyr, geom, id, count):
-    feature = ogr.Feature( feature_def = lyr.GetLayerDefn() )
+    feature = ogr.Feature(feature_def=lyr.GetLayerDefn())
     feature.SetGeometry(geom)
-    feature.SetField('BLK_ID',id)
-    feature.SetField('COUNT',count)
+    feature.SetField('BLK_ID', id)
+    feature.SetField('COUNT', count)
     result = lyr.CreateFeature(feature)
+    del result
 
 t = 0
 for leaf in leaves:
     id = leaf[0]
     ids = leaf[1]
-    count  = len(ids)
+    count = len(ids)
     # import pdb;pdb.set_trace()
 
     if len(leaf[2]) == 4:
         minx, miny, maxx, maxy = leaf[2]
     else:
         minx, miny, maxx, maxy, minz, maxz = leaf[2]
-    
+
     if id == 186:
-        print leaf[2]
-    
-    
-        
-    print leaf[2]
+        print(leaf[2])
+
+    print(leaf[2])
     leaf = make_poly(minx, miny, maxx, maxy)
-    print 'leaf: ', minx, miny, maxx, maxy
-    
+    print('leaf: ' + str([minx, miny, maxx, maxy]))
+
     pminx, pminy, pmaxx, pmaxy = get_bounds(ids, f, id)
     point = make_poly(pminx, pminy, pmaxx, pmaxy)
-    
-    print 'point:' ,pminx, pminy, pmaxx, pmaxy
-    print 'point bounds: ',point.GetArea(), area(pminx, pminy, pmaxx, pmaxy)
-    print 'leaf bounds: ', leaf.GetArea(), area(minx, miny, maxx, maxy)
-    print 'leaf - point: ', abs(point.GetArea() - leaf.GetArea())
-    print minx, miny, maxx, maxy
-  #  if shp2.GetArea() != shp.GetArea():
-  #      import pdb;pdb.set_trace()
-   # sys.exit(1)
-   
+
+    print('point: ' + str([pminx, pminy, pmaxx, pmaxy]))
+    print('point bounds: ' +
+          str([point.GetArea(), area(pminx, pminy, pmaxx, pmaxy)]))
+    print('leaf bounds: ' +
+          str([leaf.GetArea(), area(minx, miny, maxx, maxy)]))
+    print('leaf - point: ' + str([abs(point.GetArea() - leaf.GetArea())]))
+    print([minx, miny, maxx, maxy])
+    #  if shp2.GetArea() != shp.GetArea():
+    #      import pdb;pdb.set_trace()
+    # sys.exit(1)
+
     make_feature(leaf_block_lyr, leaf, id, count)
     make_feature(point_block_lyr, point, id, count)
-    
-    t+=1
-   # if t ==2:
-#        break
 
-
+    t += 1
+    # if t ==2:
+    #     break
 
 leaf_block_lyr.SyncToDisk()
 point_lyr.SyncToDisk()

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,48 @@
-from glob import glob
+#!/usr/bin/env python
 from setuptools import setup
 
 import rtree
 
 # Get text from README.txt
-readme_text = open('docs/source/README.txt', 'r').read()
+with open('docs/source/README.txt', 'r') as fp:
+    readme_text = fp.read()
 
 import os
 
 if os.name == 'nt':
-    data_files=[('Lib/site-packages/rtree',
-                 [r'D:\libspatialindex\bin\spatialindex.dll',
-                  r'D:\libspatialindex\bin\spatialindex_c.dll',]),]
+    data_files = [('Lib/site-packages/rtree',
+                  [r'D:\libspatialindex\bin\spatialindex.dll',
+                   r'D:\libspatialindex\bin\spatialindex_c.dll'])]
 else:
     data_files = None
-    
-setup(name          = 'Rtree',
-      version       = rtree.__version__,
-      description   = 'R-Tree spatial index for Python GIS',
-      license       = 'LGPL',
-      keywords      = 'gis spatial index r-tree',
-      author        = 'Sean Gillies',
-      author_email  = 'sean.gillies@gmail.com',
-      maintainer        = 'Howard Butler',
-      maintainer_email  = 'hobu@hobu.net',
-      url   = 'http://toblerity.github.com/rtree/',
-      long_description = readme_text,
-      packages      = ['rtree'],
-      install_requires = ['setuptools'],
-      test_suite = 'tests.test_suite',
-      data_files = data_files,
-      zip_safe = False,
-      classifiers   = [
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-        'Operating System :: OS Independent',
-        'Programming Language :: C',
-        'Programming Language :: C++',
-        'Programming Language :: Python',
-        'Topic :: Scientific/Engineering :: GIS',
-        'Topic :: Database',
-        ],
-)
 
+setup(
+    name          = 'Rtree',
+    version       = rtree.__version__,
+    description   = 'R-Tree spatial index for Python GIS',
+    license       = 'LGPL',
+    keywords      = 'gis spatial index r-tree',
+    author        = 'Sean Gillies',
+    author_email  = 'sean.gillies@gmail.com',
+    maintainer        = 'Howard Butler',
+    maintainer_email  = 'hobu@hobu.net',
+    url   = 'http://toblerity.github.com/rtree/',
+    long_description = readme_text,
+    packages      = ['rtree'],
+    install_requires = ['setuptools'],
+    test_suite = 'tests.test_suite',
+    data_files = data_files,
+    zip_safe = False,
+    classifiers   = [
+      'Development Status :: 5 - Production/Stable',
+      'Intended Audience :: Developers',
+      'Intended Audience :: Science/Research',
+      'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+      'Operating System :: OS Independent',
+      'Programming Language :: C',
+      'Programming Language :: C++',
+      'Programming Language :: Python',
+      'Topic :: Scientific/Engineering :: GIS',
+      'Topic :: Database',
+      ],
+)

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -2,27 +2,27 @@
 
 # Stream load:
 # 293710.04 usec/pass
-# 
+#
 # One-at-a-time load:
 # 527883.95 usec/pass
-# 
-# 
+#
+#
 # 30000 points
 # Query box:  (1240000, 1010000, 1400000, 1390000)
-# 
-# 
+#
+#
 # Brute Force:
 # 46 hits
 # 13533.60 usec/pass
-# 
+#
 # Memory-based Rtree Intersection:
 # 46 hits
 # 7516.19 usec/pass
-# 
+#
 # Disk-based Rtree Intersection:
 # 46 hits
 # 7543.00 usec/pass
-# 
+#
 # Disk-based Rtree Intersection without Item() wrapper (objects='raw'):
 # 46 raw hits
 # 347.60 usec/pass
@@ -40,6 +40,7 @@ from rtree import Rtree as _Rtree
 
 TEST_TIMES = 20
 
+
 # a very basic Geometry
 class Point(object):
     def __init__(self, x, y):
@@ -47,7 +48,7 @@ class Point(object):
         self.y = y
 
 # Scatter points randomly in a 1x1 box
-# 
+
 
 class Rtree(_Rtree):
     pickle_protocol = -1
@@ -57,7 +58,13 @@ count = 30000
 points = []
 
 insert_object = None
-insert_object = {'a': list(range(100)), 'b': 10, 'c': object(), 'd': dict(x=1), 'e': Point(2, 3)}
+insert_object = {
+    'a': list(range(100)),
+    'b': 10,
+    'c': object(),
+    'd': dict(x=1),
+    'e': Point(2, 3),
+}
 
 index = Rtree()
 disk_index = Rtree('test', overwrite=1)
@@ -73,23 +80,26 @@ for i in range(count):
     disk_index.add(i, (x, y), insert_object)
     coordinates.append((i, (x, y, x, y), insert_object))
 
-s ="""
+s = """
 bulk = Rtree(coordinates[:2000])
 """
-t = timeit.Timer(stmt=s, setup='from __main__ import coordinates, Rtree, insert_object')
+t = timeit.Timer(
+    stmt=s, setup='from __main__ import coordinates, Rtree, insert_object')
 print("\nStream load:")
 print("%.2f usec/pass" % (1000000 * t.timeit(number=TEST_TIMES)/TEST_TIMES))
 
-s ="""
+s = """
 idx = Rtree()
 i = 0
 for point in points[:2000]:
     idx.add(i, (point.x, point.y), insert_object)
     i+=1
 """
-t = timeit.Timer(stmt=s, setup='from __main__ import points, Rtree, insert_object')
+t = timeit.Timer(
+    stmt=s, setup='from __main__ import points, Rtree, insert_object')
 print("\nOne-at-a-time load:")
-print("%.2f usec/pass\n\n" % (1000000 * t.timeit(number=TEST_TIMES)/TEST_TIMES))
+print("%.2f usec/pass\n\n"
+      % (1000000 * t.timeit(number=TEST_TIMES)/TEST_TIMES))
 
 
 bbox = (1240000, 1010000, 1400000, 1390000)
@@ -99,11 +109,15 @@ print("")
 
 # Brute force all points within a 0.1x0.1 box
 s = """
-hits = [p for p in points if p.x >= bbox[0] and p.x <= bbox[2] and p.y >= bbox[1] and p.y <= bbox[3]]
+hits = [p for p in points
+        if p.x >= bbox[0] and p.x <= bbox[2]
+        and p.y >= bbox[1] and p.y <= bbox[3]]
 """
 t = timeit.Timer(stmt=s, setup='from __main__ import points, bbox')
 print("\nBrute Force:")
-print(len([p for p in points if p.x >= bbox[0] and p.x <= bbox[2] and p.y >= bbox[1] and p.y <= bbox[3]]), "hits")
+print(len([p for p in points
+           if p.x >= bbox[0] and p.x <= bbox[2] and p.y >= bbox[1]
+           and p.y <= bbox[3]]), "hits")
 print("%.2f usec/pass" % (1000000 * t.timeit(number=TEST_TIMES)/TEST_TIMES))
 
 # 0.1x0.1 box using intersection
@@ -117,7 +131,8 @@ else:
     hits = [p.object for p in index.intersection(bbox, objects=insert_object)]
     """
 
-t = timeit.Timer(stmt=s, setup='from __main__ import points, index, bbox, insert_object')
+t = timeit.Timer(
+    stmt=s, setup='from __main__ import points, index, bbox, insert_object')
 print("\nMemory-based Rtree Intersection:")
 print(len([points[id] for id in index.intersection(bbox)]), "hits")
 print("%.2f usec/pass" % (1000000 * t.timeit(number=100)/100))
@@ -126,7 +141,9 @@ print("%.2f usec/pass" % (1000000 * t.timeit(number=100)/100))
 # run same test on disk_index.
 s = s.replace("index.", "disk_index.")
 
-t = timeit.Timer(stmt=s, setup='from __main__ import points, disk_index, bbox, insert_object')
+t = timeit.Timer(
+    stmt=s,
+    setup='from __main__ import points, disk_index, bbox, insert_object')
 print("\nDisk-based Rtree Intersection:")
 hits = list(disk_index.intersection(bbox))
 print(len(hits), "hits")
@@ -137,11 +154,15 @@ if insert_object:
     s = """
         hits = disk_index.intersection(bbox, objects="raw")
         """
-    t = timeit.Timer(stmt=s, setup='from __main__ import points, disk_index, bbox, insert_object')
-    print("\nDisk-based Rtree Intersection without Item() wrapper (objects='raw'):")
+    t = timeit.Timer(
+        stmt=s,
+        setup='from __main__ import points, disk_index, bbox, insert_object')
+    print("\nDisk-based Rtree Intersection "
+          "without Item() wrapper (objects='raw'):")
     result = list(disk_index.intersection(bbox, objects="raw"))
     print(len(result), "raw hits")
-    print("%.2f usec/pass" % (1000000 * t.timeit(number=TEST_TIMES)/TEST_TIMES))
+    print("%.2f usec/pass"
+          % (1000000 * t.timeit(number=TEST_TIMES)/TEST_TIMES))
     assert 'a' in result[0], result[0]
 
 import os

--- a/tests/data.py
+++ b/tests/data.py
@@ -15,7 +15,7 @@ for line in f.readlines():
         break
     [left, bottom, right, top] = [float(x) for x in line.split()]
     boxes3.append((left, bottom, right, top))
-                
+
 points = []
 f = open(os.path.join(os.path.dirname(__file__), 'point_clusters.data'), 'r')
 for line in f.readlines():
@@ -24,16 +24,20 @@ for line in f.readlines():
     [left, bottom] = [float(x) for x in line.split()]
     points.append((left, bottom))
 
+
 def draw_data(filename):
     from PIL import Image, ImageDraw
     im = Image.new('RGB', (1440, 720))
     d = ImageDraw.Draw(im)
     for box in boxes15:
-        coords = [4.0*(box[0]+180), 4.0*(box[1]+90), 4.0*(box[2]+180), 4.0*(box[3]+90)]
+        coords = [
+            4.0*(box[0]+180), 4.0*(box[1]+90),
+            4.0*(box[2]+180), 4.0*(box[3]+90)]
         d.rectangle(coords, outline='red')
     for box in boxes3:
-        coords = [4.0*(box[0]+180), 4.0*(box[1]+90), 4.0*(box[2]+180), 4.0*(box[3]+90)]
+        coords = [
+            4.0*(box[0]+180), 4.0*(box[1]+90),
+            4.0*(box[2]+180), 4.0*(box[3]+90)]
         d.rectangle(coords, outline='blue')
 
     im.save(filename)
-    

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -3,8 +3,8 @@ import unittest
 import glob
 import os
 
-#from zope.testing import doctest
-from rtree.index import major_version, minor_version, patch_version
+# from zope.testing import doctest
+from rtree.index import major_version, minor_version  # , patch_version
 
 from .data import boxes15, boxes3, points
 
@@ -12,26 +12,30 @@ optionflags = (doctest.REPORT_ONLY_FIRST_FAILURE |
                doctest.NORMALIZE_WHITESPACE |
                doctest.ELLIPSIS)
 
+
 def list_doctests():
     # Skip the custom storage test unless we have libspatialindex 1.8+.
     return [filename
             for filename
             in glob.glob(os.path.join(os.path.dirname(__file__), '*.txt'))
             if not (
-                filename.endswith('customStorage.txt') 
+                filename.endswith('customStorage.txt')
                 and major_version < 2 and minor_version < 8)]
+
 
 def open_file(filename, mode='r'):
     """Helper function to open files from within the tests package."""
     return open(os.path.join(os.path.dirname(__file__), filename), mode)
 
+
 def setUp(test):
     test.globs.update(dict(
-            open_file = open_file,
-            boxes15=boxes15,
-            boxes3=boxes3,
-            points=points
-            ))
+        open_file=open_file,
+        boxes15=boxes15,
+        boxes3=boxes3,
+        points=points
+        ))
+
 
 def test_suite():
     return unittest.TestSuite(

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -4,6 +4,7 @@ from rtree import index
 
 from .data import boxes15
 
+
 class IndexTests(unittest.TestCase):
 
     def test_stream_input(self):
@@ -15,8 +16,8 @@ class IndexTests(unittest.TestCase):
 
 
 def boxes15_stream(interleaved=True):
-   for i, (minx, miny, maxx, maxy) in enumerate(boxes15):
-       if interleaved:
-           yield (i, (minx, miny, maxx, maxy), 42)
-       else:
-           yield (i, (minx, maxx, miny, maxy), 42)
+    for i, (minx, miny, maxx, maxy) in enumerate(boxes15):
+        if interleaved:
+            yield (i, (minx, miny, maxx, maxy), 42)
+        else:
+            yield (i, (minx, maxx, miny, maxy), 42)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -2,6 +2,7 @@ import pickle
 import unittest
 import rtree.index
 
+
 class TestPickling(unittest.TestCase):
 
     def test_index(self):
@@ -9,7 +10,7 @@ class TestPickling(unittest.TestCase):
         unpickled = pickle.loads(pickle.dumps(idx))
         self.assertNotEquals(idx.handle, unpickled.handle)
         self.assertEquals(idx.properties.as_dict(),
-            unpickled.properties.as_dict())
+                          unpickled.properties.as_dict())
         self.assertEquals(idx.interleaved, unpickled.interleaved)
 
     def test_property(self):


### PR DESCRIPTION
This patch changes the Rtree code style to adapt to the [PEP 8 Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/). There should be no functional changes, except for correction to MANIFEST.in, and making setup.py an executable. A few unused imports are also removed, and the print statement in visualize.py is updated for Python 3 (although not tested).