### PR TITLE
added env variables to find spatialindex_c

### DIFF
--- a/rtree/core.py
+++ b/rtree/core.py
@@ -102,13 +102,21 @@ if os.name == 'nt':
                     os.environ['PATH'] = oldenv
         return None
 
-    rt = _load_library('spatialindex_c.dll', ctypes.cdll.LoadLibrary)
+    if 'SPATIALINDEX_C_LIBRARY' in os.environ:
+        lib_path, lib_name = os.path.split(os.environ['SPATIALINDEX_C_LIBRARY'])
+        rt = _load_library(lib_name, ctypes.cdll.LoadLibrary, (lib_path,))
+    else:
+        rt = _load_library('spatialindex_c.dll', ctypes.cdll.LoadLibrary)
     if not rt:
         raise OSError("could not find or load spatialindex_c.dll")
 
 elif os.name == 'posix':
     platform = os.uname()[0]
-    lib_name = find_library('spatialindex_c')
+    if 'SPATIALINDEX_C_LIBRARY' in os.environ:
+        lib_name = os.environ['SPATIALINDEX_C_LIBRARY']
+    else:
+        lib_name = find_library('spatialindex_c')
+
     if lib_name is None:
         raise OSError("Could not find libspatialindex_c library file")
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,12 @@ import os
 
 if os.name == 'nt':
     data_files = [('Lib/site-packages/rtree',
-                  [r'D:\libspatialindex\bin\spatialindex.dll',
-                   r'D:\libspatialindex\bin\spatialindex_c.dll'])]
+                  [os.environ['SPATIALINDEX_LIBRARY']
+                      if 'SPATIALINDEX_LIBRARY' in os.environ else
+                      r'D:\libspatialindex\bin\spatialindex.dll',
+                   os.environ['SPATIALINDEX_C_LIBRARY']
+                      if 'SPATIALINDEX_C_LIBRARY' in os.environ else
+                      r'D:\libspatialindex\bin\spatialindex_c.dll'])]
 else:
     data_files = None
 


### PR DESCRIPTION
The SPATIALINDEX_C_LIBRARY and SPATIALINDEX_LIBRARY can be used to
specify non standard location and name (OSGeo4W64 has a spatialindex_c-64.dll)

This should address #56 and #64 

Tested on ubuntu 15.10 and windows 7.