### PR TITLE
Bake in env vars

### DIFF
--- a/rtree/core.py
+++ b/rtree/core.py
@@ -1,5 +1,6 @@
 import os
 import ctypes
+import pkgutil
 from ctypes.util import find_library
 
 
@@ -68,6 +69,16 @@ def free_error_msg_ptr(result, func, cargs):
     p = ctypes.cast(result, ctypes.POINTER(ctypes.c_void_p))
     rt.Index_Free(p)
     return retvalue
+
+# Read back env vars that were set up during package installation.
+try:
+    for line in pkgutil.get_data('rtree', 'ENVIRON.txt').decode().split():
+        kv = line.split('=')
+        if len(kv) == 2:
+            os.environ[kv[0]] = kv[1]
+except IOError:
+    # The data file doesn't exist; that is OK
+    pass
 
 
 if os.name == 'nt':

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -73,11 +73,25 @@ def free_error_msg_ptr(result, func, cargs):
 # Read back env vars that were set up during package installation.
 try:
     for line in pkgutil.get_data('rtree', 'ENVIRON.txt').decode().split():
+        # Ignore lines with wrong number of '=' signs
         kv = line.split('=')
-        if len(kv) == 2:
-            os.environ[kv[0]] = kv[1]
+        if len(kv) != 2:
+            continue
+        key, val = kv
+
+        # Only allow certain vars to be set
+        legal_envs = ('SPATIALINDEX_LIBRARY', 'SPATIALINDEX_C_LIBRARY')
+        if key not in legal_envs:
+            raise ValueError(
+                'Illegal variable in ENVIRON.txt: %s.  Must be one of %s' %
+                (key, str(legal_envs)))
+
+        # Only set from config file if not already set in env
+        if key not in os.environ:
+            os.environ[key] = val
+
 except IOError:
-    # The data file doesn't exist; that is OK
+    # The data file ENVIRON.txt doesn't exist; that is OK
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from setuptools import setup
 from setuptools.command.build_py import build_py
 
@@ -13,7 +12,7 @@ class rtree_build_py(build_py):
             target_dir = self.build_lib
 
             # mkpath is a distutils helper to create directories
-            self.mkpath(target_dir)
+            self.mkpath(os.path.join(target_dir, 'rtree'))
 
             with open(os.path.join(target_dir, 'rtree/ENVIRON.txt'), 'w') as fobj:
                 if 'SPATIALINDEX_LIBRARY' in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,29 @@
 #!/usr/bin/env python
 from setuptools import setup
+from setuptools.command.build_py import build_py
 
 import rtree
+
+# Transfer key env vars to a Python data file.
+# http://www.digip.org/blog/2011/01/generating-data-files-in-setup.py.html
+class rtree_build_py(build_py):
+    def run(self):
+        # honor the --dry-run flag
+        if not self.dry_run:
+            target_dir = self.build_lib
+
+            # mkpath is a distutils helper to create directories
+            self.mkpath(target_dir)
+
+            with open(os.path.join(target_dir, 'rtree/ENVIRON.txt'), 'w') as fobj:
+                if 'SPATIALINDEX_LIBRARY' in os.environ:
+                    fobj.write('SPATIALINDEX_LIBRARY=%s\n' % os.environ['SPATIALINDEX_LIBRARY'])
+                if 'SPATIALINDEX_C_LIBRARY' in os.environ:
+                    fobj.write('SPATIALINDEX_C_LIBRARY=%s\n' % os.environ['SPATIALINDEX_C_LIBRARY'])
+
+        # distutils uses old-style classes, so no super()
+        build_py.run(self)
+
 
 # Get text from README.txt
 with open('docs/source/README.txt', 'r') as fp:
@@ -21,6 +43,7 @@ else:
     data_files = None
 
 setup(
+    cmdclass      = {'build_py' : rtree_build_py},
     name          = 'Rtree',
     version       = rtree.__version__,
     description   = 'R-Tree spatial index for Python GIS',


### PR DESCRIPTION
When env SPATIALINDEX_LIBRARY or SPATIALINDEX_C_LIBRARY are set during setup time, bake them into the installation so they do not have to be set up at run time.  This resolves the problems I had in #56.

**To be clear:** If you do NOT set these env vars at build time, then rtree will work exactly as before: you will be able to set them at runtime.  Currently, run-time settings of these env vars do NOT override build-time settings.

Further rational for why this change is needed... I use Spack to build my software stack ( https://github.com/llnl/spack ).  How will rtree find libspatialindex?  There are a few ways this might happen:
1. Normally, Spack builds libraries with RPATH built-in.  Binaries can find their dependencies without the user having to set LD_LIBRARY_PATH.  This is really useful because it's easy to set LD_LIBRARY_PATH wrong.  Or to have binary A require one LD_LIBRARY_PATH and binary B require a different LD_LIBRARY_PATH --- and you want to be able to run them both from the same command shell.
   RPATH doesn't work here because the library is being loaded by Python code, not the system loader.
2. Spack produces an environment module for each package, which lets the package export stuff about itself.  One could upgrade the Spack package for libspatialindex to export the required env vars.  However... why should libspatialindex have to do this, just for the convenience of rtree?  This violates a principle of locality.  Rtree should be able to figure out what it needs at build time without any special help from libspatialindex (Spack already knows where libspatialindex is located at build time).

Rather than (2), it's better to modify rtree as appropriate, so libspatialindex doesn't have to set any magic env vars.  This PR does that modification, implementing a system that's functionally to the "gold-standard" RPATH described in (1).

See here for the Spack recipe for rtree.  Note how the recipe sets SPATIALINDEX_LIBRARY and SPATIALINDEX_C_LIBRARY, which get baked into the rtree install:
https://github.com/citibeth/spack/blob/efischer/develop/var/spack/repos/builtin/packages/py-rtree/package.py
