### PR TITLE
Include all text files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,4 @@
-include README.md
+include *.md *.txt
 include MANIFEST.in
-include DEPENDENCIES.txt
-include FAQ.txt
-include LICENSE.txt
 recursive-include tests *
 recursive-include docs *


### PR DESCRIPTION
The `CREDITS.txt` file is not included in the tarballs on PyPI.