### PR TITLE
Switch to container-based Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: trusty
-sudo: true
 
 language: python
 
@@ -9,9 +8,10 @@ python:
   - 3.4
   - 3.5
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install libspatialindex-dev
+addons:
+  apt:
+    packages:
+      - libspatialindex-dev
 
 install:
   - pip install -e .


### PR DESCRIPTION
The whitelist for the required package has finally been accepted, cf. travis-ci/apt-package-whitelist#4194.