### PR TITLE
Exceptions raised in callbacks are raised in main thread

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -273,7 +273,10 @@ class Index(object):
             self.properties.pagesize = int(ps)
 
         if stream:
+            self._exception = None
             self.handle = self._create_idx_from_stream(stream)
+            if self._exception:
+                raise self._exception
         else:
             self.handle = IndexHandle(self.properties.handle)
 
@@ -719,6 +722,9 @@ class Index(object):
                 p_id[0], coordinates, obj = next(stream_iter)
             except StopIteration:
                 # we're done
+                return -1
+            except Exception as exc:
+                self._exception = exc
                 return -1
 
             if self.interleaved:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -22,3 +22,20 @@ def boxes15_stream(interleaved=True):
             yield (i, (minx, miny, maxx, maxy), 42)
         else:
             yield (i, (minx, maxx, miny, maxy), 42)
+
+
+class ExceptionTests(unittest.TestCase):
+    def test_exception_in_generator(self):
+        """Assert exceptions raised in callbacks are raised in main thread"""
+        class TestException(Exception):
+            pass
+
+        def create_index():
+            def gen():
+                # insert at least 6 or so before the exception
+                for i in range(10):
+                    yield (i, (1,2,3,4), None)
+                raise TestException("raising here")
+            return index.Index(gen())
+
+        self.assertRaises(TestException, create_index)


### PR DESCRIPTION
This is an attempt at fixing #80.