### PR TITLE
DOC: fix rst formatting in changes.txt

### DIFF
--- a/docs/source/changes.txt
+++ b/docs/source/changes.txt
@@ -13,7 +13,8 @@ Changes
 - Return container sizes without returning objects #90
 - Add set_result_limit and set_result_offset for Index paging  44ad21aecd3f7b49314b9be12f3334d8bae7e827
 
-## Bug fixes
+Bug fixes:
+
 - Better exceptions in cases where stream functions throw #80 
 - Migrated CI platform to Azure Pipelines  https://dev.azure.com/hobuinc/rtree/_build?definitionId=5
 - Minor test enhancements and fixups. Both libspatialindex 1.8.5 and libspatialindex 1.9.3 are tested with CI


### PR DESCRIPTION
I was looking at the changes for the last release (https://rtree.readthedocs.io/en/latest/changes.html#id2), and this fixes the rst formatting (rst needs a blank line around lists)