### PR TITLE
Add index size and custom `__repr__` methods for index classes

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -147,7 +147,7 @@ class Index(object):
 
             >>> idx = index.Index(properties=p)
             >>> idx  # doctest: +ELLIPSIS
-            <rtree.index.Index object at 0x...>
+            rtree.index.Index(bounds=[1.7976931348623157e+308, 1.7976931348623157e+308, -1.7976931348623157e+308, -1.7976931348623157e+308], size=0)
 
         Insert an item into the index::
 
@@ -284,11 +284,14 @@ class Index(object):
                 for item in stream:
                     self.insert(*item)
 
-    def size(self):
-        return self.count(self.bounds)
+    def get_size(self):
+        try:
+            return self.count(self.bounds)
+        except core.RTreeError:
+            return 0
 
     def __repr__(self):
-        return f'rtree.index.Index(bounds={self.bounds}, size={self.size()})'
+        return f'rtree.index.Index(bounds={self.bounds}, size={self.get_size()})'
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -1827,7 +1830,7 @@ class RtreeContainer(Rtree):
 
             >>> idx = index.RtreeContainer(properties=p)
             >>> idx  # doctest: +ELLIPSIS
-            <rtree.index.RtreeContainer object at 0x...>
+            rtree.index.RtreeContainer(bounds=[1.7976931348623157e+308, 1.7976931348623157e+308, -1.7976931348623157e+308, -1.7976931348623157e+308], size=0)
 
         Insert an item into the index::
 
@@ -1852,6 +1855,15 @@ class RtreeContainer(Rtree):
                                  % self.__class__)
         self._objects = {}
         return super(RtreeContainer, self).__init__(*args, **kwargs)
+
+    def get_size(self):
+        try:
+            return self.count(self.bounds)
+        except core.RTreeError:
+            return 0
+
+    def __repr__(self):
+        return f'rtree.index.RtreeContainer(bounds={self.bounds}, size={self.get_size()})'
 
     def __contains__(self, obj):
         return id(obj) in self._objects

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -284,6 +284,12 @@ class Index(object):
                 for item in stream:
                     self.insert(*item)
 
+    def size(self):
+        return self.count(self.bounds)
+
+    def __repr__(self):
+        return f'rtree.index.Index(bounds={self.bounds}, size={self.size()})'
+
     def __getstate__(self):
         state = self.__dict__.copy()
         del state["handle"]

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -291,7 +291,7 @@ class Index(object):
             return 0
 
     def __repr__(self):
-        return f'rtree.index.Index(bounds={self.bounds}, size={self.get_size()})'
+        return 'rtree.index.Index(bounds={}, size={})'.format(self.bounds, self.get_size())
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -1863,7 +1863,7 @@ class RtreeContainer(Rtree):
             return 0
 
     def __repr__(self):
-        return f'rtree.index.RtreeContainer(bounds={self.bounds}, size={self.get_size()})'
+        return 'rtree.index.RtreeContainer(bounds={}, size={})'.format(self.bounds, self.get_size())
 
     def __contains__(self, obj):
         return id(obj) in self._objects


### PR DESCRIPTION
* Add `get_size` method for `rtree.index.Index` and `rtree.index.RtreeContainer`, which returns a count of the number of index objects/entries
* Add custom `__repr__` for both these classes that displays the current index bounds and the size count when the object is printed out to the console