### PR TITLE
Wheels can be created (for Linux)

### DIFF
--- a/rtree/.gitignore
+++ b/rtree/.gitignore
@@ -1,0 +1,2 @@
+include
+lib

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -81,7 +81,7 @@ if os.name == 'nt':
 
     def _load_library(dllname, loadfunction, dllpaths=('', )):
         """Load a DLL via ctypes load function. Return None on failure.
-        Try loading the DLL from the current package's directory first,
+        Try loading the DLL from the current package directory first,
         then from the Windows DLL search path.
         """
         try:

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -81,11 +81,11 @@ if os.name == 'nt':
 
     def _load_library(dllname, loadfunction, dllpaths=('', )):
         """Load a DLL via ctypes load function. Return None on failure.
-        Try loading the DLL from the current package's lib directory first,
+        Try loading the DLL from the current package's directory first,
         then from the Windows DLL search path.
         """
         try:
-            dllpaths = (os.path.abspath(os.path.join(os.path.dirname(__file__), "lib")),
+            dllpaths = (os.path.abspath(os.path.dirname(__file__)),
                         ) + dllpaths
         except NameError:
             pass  # no __file__ attribute on PyPy and some frozen distributions
@@ -122,8 +122,7 @@ if os.name == 'nt':
         lib_path = os.path.join(sys.prefix, "Library", "bin")
         rt = _load_library(lib_name, ctypes.cdll.LoadLibrary, (lib_path,))
     else:
-        lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "lib"))
-        rt = _load_library(lib_name, ctypes.cdll.LoadLibrary, (lib_path,))
+        rt = _load_library(lib_name, ctypes.cdll.LoadLibrary)
     import sys
     sys.stderr.write('path: %s\n' % (rt))
     if not rt:

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,15 @@ import os
 
 import itertools as it
 
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+    class bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+except ImportError:
+    bdist_wheel = None
+
 # Get text from README.txt
 with open('docs/source/README.txt', 'r') as fp:
     readme_text = fp.read()
@@ -28,6 +37,8 @@ setup(
     url   = 'https://github.com/Toblerity/rtree',
     long_description = readme_text,
     packages      = ['rtree'],
+    include_package_data=True,
+    package_data={"rtree": ["lib/*", "include/**/*", "include/**/**/*"]},
     install_requires = ['setuptools'],
     extras_require = extras_require,
     tests_require = extras_require['test'],
@@ -44,4 +55,5 @@ setup(
       'Topic :: Scientific/Engineering :: GIS',
       'Topic :: Database',
       ],
+    cmdclass={'bdist_wheel': bdist_wheel}
 )

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,11 @@ import os
 
 import itertools as it
 
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-    class bdist_wheel(_bdist_wheel):
-        def finalize_options(self):
-            _bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
-except ImportError:
-    bdist_wheel = None
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+class bdist_wheel(_bdist_wheel):
+    def finalize_options(self):
+        _bdist_wheel.finalize_options(self)
+        self.root_is_pure = False
 
 # Get text from README.txt
 with open('docs/source/README.txt', 'r') as fp:


### PR DESCRIPTION
* Only tested on my own Linux machine
* The ctypes loading is suboptimal but I have no experience with it.
* Don't know whether ALL of the libspatialindex install files are required, but currently they are all packaged along.
* I didn't make a fallback mechanism if the library is not in the `lib` dir, for example should someone use a different installation method than the wheels.