### PR TITLE
Don't import rtree in setup.py

### DIFF
--- a/rtree/__init__.py
+++ b/rtree/__init__.py
@@ -1,5 +1,1 @@
 __version__ = '0.9.4'
-
-# from .index import Rtree
-
-# from .core import rt

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-from setuptools import setup
-import rtree
 import os
 
+from setuptools import setup
 import itertools as it
 
 # Get text from README.txt
 with open('docs/source/README.txt', 'r') as fp:
     readme_text = fp.read()
+
+# Get __version without importing
+with open('rtree/__init__.py', 'r') as fp:
+    # get and exec just the line which looks like "__version__ = '0.9.4'"
+    exec(next(line for line in fp if '__version__' in line))
 
 extras_require = {
     'test': ['pytest>=3', 'pytest-cov', 'numpy']
@@ -16,32 +20,32 @@ extras_require = {
 extras_require['all'] = list(set(it.chain(*extras_require.values())))
 
 setup(
-    name          = 'Rtree',
-    version       = rtree.__version__,
-    description   = 'R-Tree spatial index for Python GIS',
-    license       = 'MIT',
-    keywords      = 'gis spatial index r-tree',
-    author        = 'Sean Gillies',
-    author_email  = 'sean.gillies@gmail.com',
-    maintainer        = 'Howard Butler',
-    maintainer_email  = 'howard@hobu.co',
-    url   = 'https://github.com/Toblerity/rtree',
-    long_description = readme_text,
-    packages      = ['rtree'],
-    install_requires = ['setuptools'],
-    extras_require = extras_require,
-    tests_require = extras_require['test'],
-    zip_safe = False,
-    classifiers   = [
-      'Development Status :: 5 - Production/Stable',
-      'Intended Audience :: Developers',
-      'Intended Audience :: Science/Research',
-      'License :: OSI Approved :: MIT License',
-      'Operating System :: OS Independent',
-      'Programming Language :: C',
-      'Programming Language :: C++',
-      'Programming Language :: Python',
-      'Topic :: Scientific/Engineering :: GIS',
-      'Topic :: Database',
-      ],
+    name='Rtree',
+    version=__version__,
+    description='R-Tree spatial index for Python GIS',
+    license='MIT',
+    keywords='gis spatial index r-tree',
+    author='Sean Gillies',
+    author_email='sean.gillies@gmail.com',
+    maintainer='Howard Butler',
+    maintainer_email='howard@hobu.co',
+    url='https://github.com/Toblerity/rtree',
+    long_description=readme_text,
+    packages=['rtree'],
+    install_requires=['setuptools'],
+    extras_require=extras_require,
+    tests_require=extras_require['test'],
+    zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: C',
+        'Programming Language :: C++',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering :: GIS',
+        'Topic :: Database',
+    ],
 )


### PR DESCRIPTION
If you try to `pip install rtree` without `libspatialindex` the pip install fails, because `setup.py` imports `rtree`. If you didn't have this, `libspatialindex` could be installed later without killing the pip install. PR'ing as I ran into https://github.com/Toblerity/rtree/issues/135 as well and this prevents the error on install. 

Setup only needs rtree to set the version, this changes it to get that version directly from `__init__.py`. This also changes whitespace in `setup.py` to match pep8. 