### PR TITLE
Hack to fix pickling

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -299,13 +299,18 @@ class Index(object):
                                                               self.get_size())
 
     def __getstate__(self):
-        state = self.__dict__.copy()
-        del state["handle"]
-        return state
+        attrs = self.__dict__.copy()
+        del attrs["handle"]
+        entries = self.intersection(self.bounds, objects=True)
+        entries = [(item.id, item.bbox, item.object) for item in entries]
+        return attrs, entries
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
+        attrs, entries = state
+        self.__dict__.update(attrs)
         self.handle = IndexHandle(self.properties.handle)
+        for item in entries:
+            self.insert(*item)
 
     def dumps(self, obj):
         return pickle.dumps(obj)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -143,13 +143,22 @@ class IndexProperties(IndexTestCase):
 
 class TestPickling(unittest.TestCase):
 
+    @unittest.expectedFailure
     def test_index(self):
         idx = rtree.index.Index()
+        idx.insert(0, [0, 1, 2, 3], 4)
         unpickled = pickle.loads(pickle.dumps(idx))
         self.assertNotEqual(idx.handle, unpickled.handle)
         self.assertEqual(idx.properties.as_dict(),
                          unpickled.properties.as_dict())
         self.assertEqual(idx.interleaved, unpickled.interleaved)
+        self.assertEqual(idx.get_size(), unpickled.get_size())
+        self.assertAlmostEqual(idx.bounds, unpickled.bounds)
+        a = next(idx.intersection(idx.bounds, objects=True))
+        b = next(unpickled.intersection(unpickled.bounds, objects=True))
+        self.assertEqual(a.id, b.id)
+        self.assertEqual(a.bounds, b.bounds)
+        self.assertEqual(a.object, b.object)
 
     def test_property(self):
         p = rtree.index.Property()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -143,7 +143,6 @@ class IndexProperties(IndexTestCase):
 
 class TestPickling(unittest.TestCase):
 
-    @unittest.expectedFailure
     def test_index(self):
         idx = rtree.index.Index()
         idx.insert(0, [0, 1, 2, 3], 4)
@@ -153,7 +152,7 @@ class TestPickling(unittest.TestCase):
                          unpickled.properties.as_dict())
         self.assertEqual(idx.interleaved, unpickled.interleaved)
         self.assertEqual(idx.get_size(), unpickled.get_size())
-        self.assertAlmostEqual(idx.bounds, unpickled.bounds)
+        self.assertEqual(idx.bounds, unpickled.bounds)
         a = next(idx.intersection(idx.bounds, objects=True))
         b = next(unpickled.intersection(unpickled.bounds, objects=True))
         self.assertEqual(a.id, b.id)


### PR DESCRIPTION
This is a hack that allows `Index` objects to be pickled. It works by copying the entire index into memory, pickling it, then rebuilding the entire index during unpickling. I hope that there is a more efficient, less hacky way to do this, but until then this at least lets users pickle rtree objects.

Fixes #87