### PR TITLE
MNT: Check return value of find_library, not LoadLibrary

### DIFF
--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -111,10 +111,10 @@ def load():
 
     try:
         # try loading library using LD path search
-        rt = ctypes.cdll.LoadLibrary(
-            find_library('spatialindex_c'))
-        if rt is not None:
-            return rt
+        path = find_library('spatialindex_c')
+        if path is not None:
+            return ctypes.cdll.LoadLibrary(path)
+
     except BaseException:
         pass
 


### PR DESCRIPTION
While chasing down a very confusing issue regarding shared libraries on macOS (not my native platform), I came across a small quirk in the way that `rtree` tries to find and load the `spatialindex_c` library. 

On macOS/Linuxc, when it cannot identify the absolute path to `libspatialindex_c.[so,dylib]`, the `rtree.finder` module falls back to using [`ctypes.util.find_library` and `ctypes.cdll.LoadLbirary`](https://github.com/Toblerity/rtree/blob/519856c462040cb29bf1ff9a43faaa48bb2865ab/rtree/finder.py#L113-L117) to find and load the shared library: 

```python
# try loading library using LD path search
rt = ctypes.cdll.LoadLibrary(
    find_library('spatialindex_c'))
if rt is not None:
    return rt
```

However (at least on certain versions of macOS/Python), calling `ctypes.cdll.LoadLibrary(None)` actually returns a `CDLL` object, not `None`:

```
$ python
Python 3.9.7 (default, Sep 16 2021, 08:50:36) 
[Clang 10.0.0 ] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ctypes
>>> ctypes.cdll.LoadLibrary(None)
<CDLL 'None', handle fffffffffffffffe at 0x7fc21c9efa60>
>>> 
```

This behaviour makes the `if rt is not None` check useless, so I propose tweaking the logic slightly, to check the return value of `find_library` instead.

Thanks!