### PR TITLE
fix order of bounding volume in 3D index tutorial

### DIFF
--- a/docs/source/tutorial.txt
+++ b/docs/source/tutorial.txt
@@ -193,8 +193,8 @@ stored on disk as the files ``3d_index.data`` and ``3d_index.index``::
   >>> p.dat_extension = 'data'
   >>> p.idx_extension = 'index'  
   >>> idx3d = index.Index('3d_index',properties=p)
-  >>> idx3d.insert(1, (0, 0, 60, 60, 23.0, 42.0))
-  >>> idx3d.intersection( (-1, -1, 62, 62, 22, 43))
+  >>> idx3d.insert(1, (0, 60, 23.0, 0, 60, 42.0))
+  >>> idx3d.intersection( (-1, 62, 22, -1, 62, 43))
   [1L]
 
 ZODB and Custom Storages


### PR DESCRIPTION
The order of the limits in the tutorial was wrong (x_low, x_high, y_low, y_high, z_low, z_high) instead of Rtree order (x_low, y_low, z_low, x_high, y_high, z_high):

```
---------------------------------------------------------------------------
RTreeError                                Traceback (most recent call last)
/tmp/ipykernel_64371/3237570581.py in <module>
     13 idx3d.insert(1, (0, 0, 30, 60, 23.0, 42.0))
     14 
---> 15 idx3d.intersection( (-1, -1, 62, 62, 22, 43))

...site-packages/rtree/index.py in intersection(self, coordinates, objects)
    680             return self._intersection_obj(coordinates, objects)
    681 
--> 682         p_mins, p_maxs = self.get_coordinate_pointers(coordinates)
    683 
    684         p_num_results = ctypes.c_uint64(0)
...site-packages/rtree/index.py in get_coordinate_pointers(self, coordinates)
    355         for i in range(dimension):
    356             if not coordinates[i] <= coordinates[i + dimension]:
--> 357                 raise core.RTreeError(
    358                     "Coordinates must not have minimums more than maximums")
    359 

RTreeError: Coordinates must not have minimums more than maximums
```