### PR TITLE
Prevent get_coordinate_pointers from mutating input coordinates

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -343,7 +343,7 @@ class Index(object):
 
         # it's a point make it into a bbox. [x, y] => [x, y, x, y]
         if len(coordinates) == dimension:
-            coordinates += coordinates
+            coordinates = *coordinates, *coordinates
 
         if len(coordinates) != dimension * 2:
             raise core.RTreeError(


### PR DESCRIPTION
`Index.get_coordinate_pointers(coordinates)` converts point-inputs to bounding boxes. However, it does so using the `+=` operator, which has the unfortunate side effect of mutating list inputs, and breaking with numpy arrays (which sum with `+=` rather than appending). This change switches from `+=` to `=` to prevent input-mutation, and uses `coordinates = *coordinates, *coordinates` for numpy compatibility.  

**Before**
``` Python
In [1]: import numpy as np
   ...: import rtree
   ...:
   ...: boxes15 = np.genfromtxt('boxes_15x15.data')
   ...: idx = rtree.index.Index()
   ...: for i, coords in enumerate(boxes15):
   ...:     idx.add(i, coords)

In [2]: # Tuples work and are not mutated (good)
   ...: point = 64, 64
   ...: list(idx.intersection(point))
Out[2]: [4, 53]

In [3]: point
Out[3]: (64, 64)

In [4]: # Lists work but are mutated (bad)
   ...: point = [64, 64]
   ...: list(idx.intersection(point))
Out[4]: [4, 53]

In [5]: point
Out[5]: [64, 64, 64, 64]  # <-- Mutated

In [6]: # Numpy arrays don't work (and would also be mutated) (bad)
   ...: point = np.array([64, 64])
   ...: idx.intersection(point)  # Breaks because `+=` sums in numpy rather than appends
---------------------------------------------------------------------------
RTreeError                                Traceback (most recent call last)
<ipython-input-6-1051681b49f7> in <module>
      1 point = np.array([64, 64])
----> 2 idx.intersection(point)  # Breaks because `+=` sums in numpy rather than appends

~/opt/anaconda3/envs/rtree/lib/python3.8/site-packages/rtree/index.py in intersection(self, coordinates, objects)
    675             return self._intersection_obj(coordinates, objects)
    676
--> 677         p_mins, p_maxs = self.get_coordinate_pointers(coordinates)
    678
    679         p_num_results = ctypes.c_uint64(0)

~/opt/anaconda3/envs/rtree/lib/python3.8/site-packages/rtree/index.py in get_coordinate_pointers(self, coordinates)
    342
    343         if len(coordinates) != dimension * 2:
--> 344             raise core.RTreeError(
    345                 "Coordinates must be in the form "
    346                 "(minx, miny, maxx, maxy) or (x, y) for 2D indexes")

RTreeError: Coordinates must be in the form (minx, miny, maxx, maxy) or (x, y) for 2D indexes
```

**After**
``` Python
In [1]: import numpy as np
   ...: import rtree
   ...:
   ...: boxes15 = np.genfromtxt('boxes_15x15.data')
   ...: idx = rtree.index.Index()
   ...: for i, coords in enumerate(boxes15):
   ...:     idx.add(i, coords)

In [2]: point = 64, 64
   ...: list(idx.intersection(point))
Out[2]: [4, 53]

In [3]: point
Out[3]: (64, 64)

In [4]: point = [64, 64]
   ...: list(idx.intersection(point))
Out[4]: [4, 53]

In [5]: point
Out[5]: [64, 64]

In [6]: point = np.array([64, 64])

In [7]: list(idx.intersection(point))
Out[7]: [4, 53]

In [8]: point
Out[8]: array([64, 64])
```