### PR TITLE
Add __len__ method to Index

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -289,10 +289,23 @@ class Index(object):
                     self.insert(*item)
 
     def get_size(self):
+        """The number of entries in the index.
+
+        :return: number of entries
+        :rtype: int
+        """
         try:
             return self.count(self.bounds)
         except core.RTreeError:
             return 0
+
+    def __len__(self):
+        """The number of entries in the index.
+
+        :return: number of entries
+        :rtype: int
+        """
+        return self.get_size()
 
     def __repr__(self):
         return 'rtree.index.Index(bounds={}, size={})'.format(self.bounds,

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -2,6 +2,7 @@ import ctypes
 import os
 import os.path
 import pprint
+import warnings
 
 from . import core
 
@@ -289,6 +290,13 @@ class Index(object):
                     self.insert(*item)
 
     def get_size(self):
+        warnings.warn(
+            "index.get_size() is deprecated, use len(index) instead",
+            DeprecationWarning,
+        )
+        return len(self)
+
+    def __len__(self):
         """The number of entries in the index.
 
         :return: number of entries
@@ -298,14 +306,6 @@ class Index(object):
             return self.count(self.bounds)
         except core.RTreeError:
             return 0
-
-    def __len__(self):
-        """The number of entries in the index.
-
-        :return: number of entries
-        :rtype: int
-        """
-        return self.get_size()
 
     def __repr__(self):
         return 'rtree.index.Index(bounds={}, size={})'.format(self.bounds,

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -57,7 +57,8 @@ class IndexCount(unittest.TestCase):
         self.assertEqual(len(self.idx), len(self.boxes15))
 
     def test_get_size(self):
-        self.assertEqual(self.idx.get_size(), len(self.boxes15))
+        with pytest.deprecated_call():
+            self.assertEqual(self.idx.get_size(), len(self.boxes15))
 
 
 class IndexBounds(unittest.TestCase):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -45,6 +45,21 @@ class IndexVersion(unittest.TestCase):
         self.assertTrue(index.minor_version >= 7)
 
 
+class IndexCount(unittest.TestCase):
+
+    def setUp(self):
+        self.boxes15 = np.genfromtxt('boxes_15x15.data')
+        self.idx = index.Index()
+        for i, coords in enumerate(self.boxes15):
+            self.idx.add(i, coords)
+
+    def test_len(self):
+        self.assertEqual(len(self.idx), len(self.boxes15))
+
+    def test_get_size(self):
+        self.assertEqual(self.idx.get_size(), len(self.boxes15))
+
+
 class IndexBounds(unittest.TestCase):
 
     def test_invalid_specifications(self):


### PR DESCRIPTION
This PR adds a `__len__` method to `Index`, defining the length of an index as the number of entries in that index. This is analogous to the definition of length for Python sets.

This PR also documents and tests the `get_size` method which provides identical functionality. This method has never been documented before. Should we deprecate or remove it in favor of `__len__`? It's definitely more Pythonic to rely on these kinds of magic methods instead of `get_*` and `set_*` methods.

Closes #194 

@hobu 