### PR TITLE
pytest: update deprecated fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ data_files = [
 ]
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def temporary_working_directory(tmpdir):
     for filename in data_files:
         filename = os.path.join(os.path.dirname(__file__), filename)


### PR DESCRIPTION
Running the unit tests with pytest results in the following deprecation warnings:
```
tests/conftest.py:12
  /Users/Adam/Downloads/rtree/tests/conftest.py:12: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(autouse=True)
```
This PR updates the fixture to its modern name.