### PR TITLE
Index/Item: add intersection/union support

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -676,26 +676,37 @@ class Index:
         i = 0
         new_idx = Index(interleaved=self.interleaved, properties=self.properties)
 
-        # For each Item in self...
-        for item1 in self.intersection(self.bounds, objects=True):
-            # For each Item in other that intersects...
-            for item2 in other.intersection(item1.bounds, objects=True):
-                # Compute the intersection bounding box
-                bounds = []
-                for j in range(len(item1.bounds)):
-                    if self.interleaved:
-                        if j < len(item1.bounds) // 2:
-                            bounds.append(max(item1.bounds[j], item2.bounds[j]))
+        if self.interleaved:
+            # For each Item in self...
+            for item1 in self.intersection(self.bounds, objects=True):
+                # For each Item in other that intersects...
+                for item2 in other.intersection(item1.bbox, objects=True):
+                    # Compute the intersection bounding box
+                    bbox = []
+                    for j in range(len(item1.bbox)):
+                        if j < len(item1.bbox) // 2:
+                            bbox.append(max(item1.bbox[j], item2.bbox[j]))
                         else:
-                            bounds.append(min(item1.bounds[j], item2.bounds[j]))
-                    else:
+                            bbox.append(min(item1.bbox[j], item2.bbox[j]))
+
+                    new_idx.insert(i, bbox, (item1.object, item2.object))
+                    i += 1
+
+        else:
+            # For each Item in self...
+            for item1 in self.intersection(self.bounds, objects=True):
+                # For each Item in other that intersects...
+                for item2 in other.intersection(item1.bounds, objects=True):
+                    # Compute the intersection bounding box
+                    bounds = []
+                    for j in range(len(item1.bounds)):
                         if j % 2 == 0:
                             bounds.append(max(item1.bounds[j], item2.bounds[j]))
                         else:
                             bounds.append(min(item1.bounds[j], item2.bounds[j]))
 
-                new_idx.insert(i, bounds, (item1.object, item2.object))
-                i += 1
+                    new_idx.insert(i, bounds, (item1.object, item2.object))
+                    i += 1
 
         return new_idx
 
@@ -715,7 +726,10 @@ class Index:
         for old_idx in [self, other]:
             # For each item...
             for item in old_idx.intersection(old_idx.bounds, objects=True):
-                new_idx.insert(item.id, item.bounds, item.object)
+                if self.interleaved:
+                    new_idx.insert(item.id, item.bbox, item.object)
+                else:
+                    new_idx.insert(item.id, item.bounds, item.object)
 
         return new_idx
 

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -663,6 +663,31 @@ class Index:
         )
         return self._get_ids(it, p_num_results.value)
 
+    def __and__(self, other: Index) -> Index:
+        """Take the intersection of two Index objects.
+
+        :param other: another index
+        :return: a new index
+        """
+        new_idx = Index(properties=self.properties)
+        for item1 in self.intersection(self.bounds, objects=True):
+            for item2 in other.intersection(item1.bounds, objects=True):
+                item3 = item1 & item2
+                new_idx.insert(item3.id, item3.bounds, item3.object)
+        return new_idx
+
+    def __or__(self, other: Index) -> Index:
+        """Take the union of two Index objects.
+
+        :param other: another index
+        :return: a new index
+        """
+        new_idx = Index(properties=self.properties)
+        for old_idx in [self, other]:
+            for item in old_idx.intersection(old_idx.bounds, objects=True):
+                new_idx.insert(item.id, item.bounds, item.object)
+        return new_idx
+
     @overload
     def intersection(self, coordinates: Any, objects: Literal[True]) -> Iterator[Item]:
         ...

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -676,9 +676,9 @@ class Index:
         i = 0
         new_idx = Index(interleaved=self.interleaved, properties=self.properties)
 
-        if self.interleaved:
-            # For each Item in self...
-            for item1 in self.intersection(self.bounds, objects=True):
+        # For each Item in self...
+        for item1 in self.intersection(self.bounds, objects=True):
+            if self.interleaved:
                 # For each Item in other that intersects...
                 for item2 in other.intersection(item1.bbox, objects=True):
                     # Compute the intersection bounding box
@@ -692,9 +692,7 @@ class Index:
                     new_idx.insert(i, bbox, (item1.object, item2.object))
                     i += 1
 
-        else:
-            # For each Item in self...
-            for item1 in self.intersection(self.bounds, objects=True):
+            else:
                 # For each Item in other that intersects...
                 for item2 in other.intersection(item1.bounds, objects=True):
                     # Compute the intersection bounding box


### PR DESCRIPTION
Still a work in progress. I was planning on taking the intersection of two Item objects but the Item constructor doesn't seem to contain bounds so it's unclear how to do this. Also, things might be different depending on interleave=True/False. Will definitely need extensive testing.

Closes #209 