### PR TITLE
Test docs using ReadTheDocs CI instead of GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,44 +81,6 @@ jobs:
       run: |
         python3 -m pytest --doctest-modules rtree tests
 
-  docs:
-    name: Docs
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    container: osgeo/proj-docs
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      name: Install Python
-      with:
-        python-version: '3.10'
-    - name: Run libspatialindex build
-      run: |
-        apt-get update -y
-        apt-get install -y -qq libspatialindex-dev
-        pip3 install --user .
-    - name: Print versions
-      shell: bash -l {0}
-      run: |
-          python3 --version
-          sphinx-build --version
-    - name: Lint .rst files
-      shell: bash -l {0}
-      run: |
-        if find . -name '*.rst' | xargs grep -P '\t'; then echo 'Tabs are bad, please use four spaces in .rst files.'; false; fi
-      working-directory: ./docs
-    - name: HTML
-      shell: bash -l {0}
-      run: |
-        make html
-      working-directory: ./docs
-    - name: PDF
-      shell: bash -l {0}
-      run: |
-        make latexpdf
-      working-directory: ./docs
-
   wheels:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+   apt_packages:
+      - libspatialindex-dev
+   os: ubuntu-20.04
+   tools:
+      python: "3.10"
+
+# Build documentation in the docs/source directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+   fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - pdf

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-python:
-  version: 3
-  pip_install: true
-conda:
-  file: environment.yml


### PR DESCRIPTION
ReadTheDocs has its own CI platform. We should use this instead of GitHub Actions for the following reasons:

* Identical environment as the one where the docs are actually hosted
* Better control over Python version used during testing (#212)
* Able to preview docs for a PR before it is merged

This PR updates `.readthedocs.yaml` to the latest API and sets `fail_on_warning: true` so we can catch documentation issues before a PR is merged. However, to get ReadTheDocs CI set up, someone with admin privileges will need to configure a few additional things. @hobu can you follow the instructions at https://docs.readthedocs.io/en/stable/pull-requests.html and see if that works?

@mwtoews may also be interested in this.