### PR TITLE
Blacken repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,19 @@ on:
     types:
       - published
 jobs:
+  black:
+    name: black
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Setup
+      run: pip install black
+    - name: Lint with black
+      run: black --check --diff .
+
   flake8:
     name: flake8
     runs-on: ubuntu-latest
@@ -19,6 +32,19 @@ jobs:
       run: pip install flake8
     - name: Lint with flake8
       run: flake8
+
+  isort:
+    name: isort
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Setup
+      run: pip install isort
+    - name: Lint with isort
+      run: isort --check --diff .
 
   conda:
     name: Conda ${{ matrix.python-version }} - ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Setup
-      run: pip install isort
+      run: pip install isort[colors]
     - name: Lint with isort
       run: isort --check --diff .
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,10 +11,11 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import rtree
 import sys
-sys.path.append('../../')
 
+sys.path.append("../../")
+
+import rtree  # noqa: E402
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -26,28 +27,29 @@ sys.path.append('../../')
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.ifconfig']
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.ifconfig",
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = '.txt'
+source_suffix = ".txt"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'Rtree'
-copyright = u'2019, Sean Gilles, Howard Butler, and contributors.'
+project = "Rtree"
+copyright = "2019, Sean Gilles, Howard Butler, and contributors."
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -90,7 +92,7 @@ exclude_trees = []
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -100,7 +102,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = 'nature'
+html_theme = "nature"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -129,7 +131,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -173,7 +175,7 @@ html_static_path = ['_static']
 # html_file_suffix = ''
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Rtreedoc'
+htmlhelp_basename = "Rtreedoc"
 
 
 # -- Options for LaTeX output --------------------------------------------
@@ -187,8 +189,7 @@ htmlhelp_basename = 'Rtreedoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'Rtree.tex', u'Rtree Documentation',
-     u'Sean Gilles', 'manual'),
+    ("index", "Rtree.tex", "Rtree Documentation", "Sean Gilles", "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -208,16 +209,14 @@ latex_documents = [
 # If false, no module index is generated.
 # latex_use_modindex = True
 
-pdf_documents = [
-    ('index', u'Rtree', u'Rtree Documentation', u'The Rtree Team'),
-]
+pdf_documents = [("index", "Rtree", "Rtree Documentation", "The Rtree Team")]
 
 # A comma-separated list of custom stylesheets. Example:
 pdf_language = "en_US"
 pdf_fit_mode = "overflow"
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {"http://docs.python.org/": None}
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {"http://docs.python.org/": None}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [build-system]
 requires = ["wheel", "setuptools>=39.2"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+target-version = ['py37', 'py38', 'py39']
+color = true
+skip_magic_trailing_comma = true
+
+[tool.isort]
+profile = "black"
+known_first_party = ["rtree"]
+skip_gitignore = true
+color_output = true

--- a/rtree/__init__.py
+++ b/rtree/__init__.py
@@ -4,6 +4,6 @@
 Rtree provides Python bindings to libspatialindex for quick
 hyperrectangular intersection queries.
 """
-__version__ = '0.9.7'
+__version__ = "0.9.7"
 
-from .index import Rtree, Index  # noqa
+from .index import Index, Rtree  # noqa

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -8,8 +8,7 @@ def check_return(result, func, cargs):
     "Error checking for Error calls"
     if result != 0:
         s = rt.Error_GetLastErrorMsg().decode()
-        msg = 'LASError in "%s": %s' % \
-            (func.__name__, s)
+        msg = 'LASError in "%s": %s' % (func.__name__, s)
         rt.Error_Reset()
         raise RTreeError(msg)
     return True
@@ -93,13 +92,15 @@ rt.Index_Create.argtypes = [ctypes.c_void_p]
 rt.Index_Create.restype = ctypes.c_void_p
 rt.Index_Create.errcheck = check_void
 
-NEXTFUNC = ctypes.CFUNCTYPE(ctypes.c_int,
-                            ctypes.POINTER(ctypes.c_int64),
-                            ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                            ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                            ctypes.POINTER(ctypes.c_uint32),
-                            ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
-                            ctypes.POINTER(ctypes.c_uint32))
+NEXTFUNC = ctypes.CFUNCTYPE(
+    ctypes.c_int,
+    ctypes.POINTER(ctypes.c_int64),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+    ctypes.POINTER(ctypes.c_uint32),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
+    ctypes.POINTER(ctypes.c_uint32),
+)
 
 rt.Index_CreateWithStream.argtypes = [ctypes.c_void_p, NEXTFUNC]
 rt.Index_CreateWithStream.restype = ctypes.c_void_p
@@ -113,28 +114,34 @@ rt.Index_GetProperties.argtypes = [ctypes.c_void_p]
 rt.Index_GetProperties.restype = ctypes.c_void_p
 rt.Index_GetProperties.errcheck = check_void
 
-rt.Index_DeleteData.argtypes = [ctypes.c_void_p,
-                                ctypes.c_int64,
-                                ctypes.POINTER(ctypes.c_double),
-                                ctypes.POINTER(ctypes.c_double),
-                                ctypes.c_uint32]
+rt.Index_DeleteData.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int64,
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.c_uint32,
+]
 rt.Index_DeleteData.restype = ctypes.c_int
 rt.Index_DeleteData.errcheck = check_return
 
-rt.Index_InsertData.argtypes = [ctypes.c_void_p,
-                                ctypes.c_int64,
-                                ctypes.POINTER(ctypes.c_double),
-                                ctypes.POINTER(ctypes.c_double),
-                                ctypes.c_uint32,
-                                ctypes.POINTER(ctypes.c_ubyte),
-                                ctypes.c_uint32]
+rt.Index_InsertData.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int64,
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.c_uint32,
+    ctypes.POINTER(ctypes.c_ubyte),
+    ctypes.c_uint32,
+]
 rt.Index_InsertData.restype = ctypes.c_int
 rt.Index_InsertData.errcheck = check_return
 
-rt.Index_GetBounds.argtypes = [ctypes.c_void_p,
-                               ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                               ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
-                               ctypes.POINTER(ctypes.c_uint32)]
+rt.Index_GetBounds.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+    ctypes.POINTER(ctypes.c_uint32),
+]
 rt.Index_GetBounds.restype = ctypes.c_int
 rt.Index_GetBounds.errcheck = check_value
 
@@ -142,69 +149,76 @@ rt.Index_IsValid.argtypes = [ctypes.c_void_p]
 rt.Index_IsValid.restype = ctypes.c_int
 rt.Index_IsValid.errcheck = check_value
 
-rt.Index_Intersects_obj.argtypes = [ctypes.c_void_p,
-                                    ctypes.POINTER(ctypes.c_double),
-                                    ctypes.POINTER(ctypes.c_double),
-                                    ctypes.c_uint32,
-                                    ctypes.POINTER(
-                                        ctypes.POINTER(ctypes.c_void_p)),
-                                    ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_Intersects_obj.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.c_uint32,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+    ctypes.POINTER(ctypes.c_uint64),
+]
 rt.Index_Intersects_obj.restype = ctypes.c_int
 rt.Index_Intersects_obj.errcheck = check_return
 
 
-rt.Index_Intersects_id.argtypes = [ctypes.c_void_p,
-                                   ctypes.POINTER(ctypes.c_double),
-                                   ctypes.POINTER(ctypes.c_double),
-                                   ctypes.c_uint32,
-                                   ctypes.POINTER(
-                                       ctypes.POINTER(ctypes.c_int64)),
-                                   ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_Intersects_id.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.c_uint32,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
+    ctypes.POINTER(ctypes.c_uint64),
+]
 rt.Index_Intersects_id.restype = ctypes.c_int
 rt.Index_Intersects_id.errcheck = check_return
 
-rt.Index_Intersects_count.argtypes = [ctypes.c_void_p,
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.c_uint32,
-                                      ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_Intersects_count.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.c_uint32,
+    ctypes.POINTER(ctypes.c_uint64),
+]
 
-rt.Index_NearestNeighbors_obj.argtypes = [ctypes.c_void_p,
-                                          ctypes.POINTER(ctypes.c_double),
-                                          ctypes.POINTER(ctypes.c_double),
-                                          ctypes.c_uint32,
-                                          ctypes.POINTER(
-                                              ctypes.POINTER(ctypes.c_void_p)),
-                                          ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_NearestNeighbors_obj.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.c_uint32,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+    ctypes.POINTER(ctypes.c_uint64),
+]
 rt.Index_NearestNeighbors_obj.restype = ctypes.c_int
 rt.Index_NearestNeighbors_obj.errcheck = check_return
 
-rt.Index_NearestNeighbors_id.argtypes = [ctypes.c_void_p,
-                                         ctypes.POINTER(ctypes.c_double),
-                                         ctypes.POINTER(ctypes.c_double),
-                                         ctypes.c_uint32,
-                                         ctypes.POINTER(
-                                             ctypes.POINTER(ctypes.c_int64)),
-                                         ctypes.POINTER(ctypes.c_uint64)]
+rt.Index_NearestNeighbors_id.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.POINTER(ctypes.c_double),
+    ctypes.c_uint32,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
+    ctypes.POINTER(ctypes.c_uint64),
+]
 rt.Index_NearestNeighbors_id.restype = ctypes.c_int
 rt.Index_NearestNeighbors_id.errcheck = check_return
 
-rt.Index_GetLeaves.argtypes = [ctypes.c_void_p,
-                               ctypes.POINTER(ctypes.c_uint32),
-                               ctypes.POINTER(ctypes.POINTER(ctypes.c_uint32)),
-                               ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
-                               ctypes.POINTER(ctypes.POINTER(
-                                   ctypes.POINTER(ctypes.c_int64))),
-                               ctypes.POINTER(ctypes.POINTER(
-                                   ctypes.POINTER(ctypes.c_double))),
-                               ctypes.POINTER(ctypes.POINTER(
-                                   ctypes.POINTER(ctypes.c_double))),
-                               ctypes.POINTER(ctypes.c_uint32)]
+rt.Index_GetLeaves.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_uint32),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_uint32)),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
+    ctypes.POINTER(ctypes.POINTER(ctypes.POINTER(ctypes.c_int64))),
+    ctypes.POINTER(ctypes.POINTER(ctypes.POINTER(ctypes.c_double))),
+    ctypes.POINTER(ctypes.POINTER(ctypes.POINTER(ctypes.c_double))),
+    ctypes.POINTER(ctypes.c_uint32),
+]
 rt.Index_GetLeaves.restype = ctypes.c_int
 rt.Index_GetLeaves.errcheck = check_return
 
-rt.Index_DestroyObjResults.argtypes = \
-    [ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)), ctypes.c_uint32]
+rt.Index_DestroyObjResults.argtypes = [
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+    ctypes.c_uint32,
+]
 rt.Index_DestroyObjResults.restype = None
 rt.Index_DestroyObjResults.errcheck = check_void_done
 
@@ -219,19 +233,20 @@ rt.IndexItem_Destroy.argtypes = [ctypes.c_void_p]
 rt.IndexItem_Destroy.restype = None
 rt.IndexItem_Destroy.errcheck = check_void_done
 
-rt.IndexItem_GetData.argtypes = [ctypes.c_void_p,
-                                 ctypes.POINTER(
-                                     ctypes.POINTER(ctypes.c_ubyte)),
-                                 ctypes.POINTER(ctypes.c_uint64)]
+rt.IndexItem_GetData.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
+    ctypes.POINTER(ctypes.c_uint64),
+]
 rt.IndexItem_GetData.restype = ctypes.c_int
 rt.IndexItem_GetData.errcheck = check_value
 
-rt.IndexItem_GetBounds.argtypes = [ctypes.c_void_p,
-                                   ctypes.POINTER(
-                                       ctypes.POINTER(ctypes.c_double)),
-                                   ctypes.POINTER(
-                                       ctypes.POINTER(ctypes.c_double)),
-                                   ctypes.POINTER(ctypes.c_uint32)]
+rt.IndexItem_GetBounds.argtypes = [
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+    ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+    ctypes.POINTER(ctypes.c_uint32),
+]
 rt.IndexItem_GetBounds.restype = ctypes.c_int
 rt.IndexItem_GetBounds.errcheck = check_value
 
@@ -266,7 +281,7 @@ try:
         ctypes.POINTER(ctypes.c_double),
         ctypes.c_uint32,
         ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
-        ctypes.POINTER(ctypes.c_uint64)
+        ctypes.POINTER(ctypes.c_uint64),
     ]
     rt.Index_Contains_obj.restype = ctypes.c_int
     rt.Index_Contains_obj.errcheck = check_return
@@ -277,7 +292,7 @@ try:
         ctypes.POINTER(ctypes.c_double),
         ctypes.c_uint32,
         ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
-        ctypes.POINTER(ctypes.c_uint64)
+        ctypes.POINTER(ctypes.c_uint64),
     ]
     rt.Index_Contains_id.restype = ctypes.c_int
     rt.Index_Contains_id.errcheck = check_return
@@ -349,8 +364,7 @@ rt.IndexProperty_GetPagesize.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetPagesize.restype = ctypes.c_int
 rt.IndexProperty_GetPagesize.errcheck = check_value
 
-rt.IndexProperty_SetLeafPoolCapacity.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetLeafPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetLeafPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetLeafPoolCapacity.errcheck = check_return
 
@@ -358,8 +372,7 @@ rt.IndexProperty_GetLeafPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetLeafPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetLeafPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetIndexPoolCapacity.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetIndexPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetIndexPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetIndexPoolCapacity.errcheck = check_return
 
@@ -367,8 +380,7 @@ rt.IndexProperty_GetIndexPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetIndexPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetIndexPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetRegionPoolCapacity.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetRegionPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetRegionPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetRegionPoolCapacity.errcheck = check_return
 
@@ -376,8 +388,7 @@ rt.IndexProperty_GetRegionPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetRegionPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetRegionPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetPointPoolCapacity.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetPointPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetPointPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetPointPoolCapacity.errcheck = check_return
 
@@ -385,8 +396,7 @@ rt.IndexProperty_GetPointPoolCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetPointPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetPointPoolCapacity.errcheck = check_value
 
-rt.IndexProperty_SetBufferingCapacity.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetBufferingCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetBufferingCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetBufferingCapacity.errcheck = check_return
 
@@ -394,8 +404,7 @@ rt.IndexProperty_GetBufferingCapacity.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetBufferingCapacity.restype = ctypes.c_int
 rt.IndexProperty_GetBufferingCapacity.errcheck = check_value
 
-rt.IndexProperty_SetEnsureTightMBRs.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetEnsureTightMBRs.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
 rt.IndexProperty_SetEnsureTightMBRs.restype = ctypes.c_int
 rt.IndexProperty_SetEnsureTightMBRs.errcheck = check_return
 
@@ -411,8 +420,10 @@ rt.IndexProperty_GetOverwrite.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetOverwrite.restype = ctypes.c_int
 rt.IndexProperty_GetOverwrite.errcheck = check_value
 
-rt.IndexProperty_SetNearMinimumOverlapFactor.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetNearMinimumOverlapFactor.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_uint32,
+]
 rt.IndexProperty_SetNearMinimumOverlapFactor.restype = ctypes.c_int
 rt.IndexProperty_SetNearMinimumOverlapFactor.errcheck = check_return
 
@@ -436,8 +447,10 @@ rt.IndexProperty_GetFillFactor.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFillFactor.restype = ctypes.c_double
 rt.IndexProperty_GetFillFactor.errcheck = check_value
 
-rt.IndexProperty_SetSplitDistributionFactor.argtypes = \
-    [ctypes.c_void_p, ctypes.c_double]
+rt.IndexProperty_SetSplitDistributionFactor.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_double,
+]
 rt.IndexProperty_SetSplitDistributionFactor.restype = ctypes.c_int
 rt.IndexProperty_SetSplitDistributionFactor.errcheck = check_return
 
@@ -453,8 +466,7 @@ rt.IndexProperty_GetTPRHorizon.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetTPRHorizon.restype = ctypes.c_double
 rt.IndexProperty_GetTPRHorizon.errcheck = check_value
 
-rt.IndexProperty_SetReinsertFactor.argtypes = \
-    [ctypes.c_void_p, ctypes.c_double]
+rt.IndexProperty_SetReinsertFactor.argtypes = [ctypes.c_void_p, ctypes.c_double]
 rt.IndexProperty_SetReinsertFactor.restype = ctypes.c_int
 rt.IndexProperty_SetReinsertFactor.errcheck = check_return
 
@@ -470,28 +482,26 @@ rt.IndexProperty_GetFileName.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFileName.errcheck = free_returned_char_p
 rt.IndexProperty_GetFileName.restype = ctypes.POINTER(ctypes.c_char)
 
-rt.IndexProperty_SetFileNameExtensionDat.argtypes = \
-    [ctypes.c_void_p, ctypes.c_char_p]
+rt.IndexProperty_SetFileNameExtensionDat.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 rt.IndexProperty_SetFileNameExtensionDat.restype = ctypes.c_int
 rt.IndexProperty_SetFileNameExtensionDat.errcheck = check_return
 
 rt.IndexProperty_GetFileNameExtensionDat.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFileNameExtensionDat.errcheck = free_returned_char_p
-rt.IndexProperty_GetFileNameExtensionDat.restype = \
-    ctypes.POINTER(ctypes.c_char)
+rt.IndexProperty_GetFileNameExtensionDat.restype = ctypes.POINTER(ctypes.c_char)
 
-rt.IndexProperty_SetFileNameExtensionIdx.argtypes = \
-    [ctypes.c_void_p, ctypes.c_char_p]
+rt.IndexProperty_SetFileNameExtensionIdx.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 rt.IndexProperty_SetFileNameExtensionIdx.restype = ctypes.c_int
 rt.IndexProperty_SetFileNameExtensionIdx.errcheck = check_return
 
 rt.IndexProperty_GetFileNameExtensionIdx.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetFileNameExtensionIdx.errcheck = free_returned_char_p
-rt.IndexProperty_GetFileNameExtensionIdx.restype = \
-    ctypes.POINTER(ctypes.c_char)
+rt.IndexProperty_GetFileNameExtensionIdx.restype = ctypes.POINTER(ctypes.c_char)
 
-rt.IndexProperty_SetCustomStorageCallbacksSize.argtypes = \
-    [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetCustomStorageCallbacksSize.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_uint32,
+]
 rt.IndexProperty_SetCustomStorageCallbacksSize.restype = ctypes.c_int
 rt.IndexProperty_SetCustomStorageCallbacksSize.errcheck = check_return
 
@@ -499,8 +509,7 @@ rt.IndexProperty_GetCustomStorageCallbacksSize.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetCustomStorageCallbacksSize.restype = ctypes.c_uint32
 rt.IndexProperty_GetCustomStorageCallbacksSize.errcheck = check_value
 
-rt.IndexProperty_SetCustomStorageCallbacks.argtypes = \
-    [ctypes.c_void_p, ctypes.c_void_p]
+rt.IndexProperty_SetCustomStorageCallbacks.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 rt.IndexProperty_SetCustomStorageCallbacks.restype = ctypes.c_int
 rt.IndexProperty_SetCustomStorageCallbacks.errcheck = check_return
 
@@ -529,69 +538,77 @@ rt.SIDX_Version.errcheck = free_returned_char_p
 
 # TPR-Tree API
 try:
-    rt.Index_InsertTPData.argtypes = [ctypes.c_void_p,
-                                      ctypes.c_int64,
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.c_double,
-                                      ctypes.c_double,
-                                      ctypes.c_uint32,
-                                      ctypes.POINTER(ctypes.c_ubyte),
-                                      ctypes.c_uint32]
+    rt.Index_InsertTPData.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int64,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_double,
+        ctypes.c_double,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_ubyte),
+        ctypes.c_uint32,
+    ]
     rt.Index_InsertTPData.restype = ctypes.c_int
     rt.Index_InsertTPData.errcheck = check_return
 
-    rt.Index_DeleteTPData.argtypes = [ctypes.c_void_p,
-                                      ctypes.c_int64,
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.POINTER(ctypes.c_double),
-                                      ctypes.c_double,
-                                      ctypes.c_double,
-                                      ctypes.c_uint32]
+    rt.Index_DeleteTPData.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int64,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_double,
+        ctypes.c_double,
+        ctypes.c_uint32,
+    ]
     rt.Index_DeleteTPData.restype = ctypes.c_int
     rt.Index_DeleteTPData.errcheck = check_return
 
-    rt.Index_TPIntersects_id.argtypes = [ctypes.c_void_p,
-                                         ctypes.POINTER(ctypes.c_double),
-                                         ctypes.POINTER(ctypes.c_double),
-                                         ctypes.POINTER(ctypes.c_double),
-                                         ctypes.POINTER(ctypes.c_double),
-                                         ctypes.c_double,
-                                         ctypes.c_double,
-                                         ctypes.c_uint32,
-                                         ctypes.POINTER(
-                                             ctypes.POINTER(ctypes.c_int64)),
-                                         ctypes.POINTER(ctypes.c_uint64)]
+    rt.Index_TPIntersects_id.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_double,
+        ctypes.c_double,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
+        ctypes.POINTER(ctypes.c_uint64),
+    ]
     rt.Index_TPIntersects_id.restype = ctypes.c_int
     rt.Index_TPIntersects_id.errcheck = check_return
 
-    rt.Index_TPIntersects_obj.argtypes = [ctypes.c_void_p,
-                                          ctypes.POINTER(ctypes.c_double),
-                                          ctypes.POINTER(ctypes.c_double),
-                                          ctypes.POINTER(ctypes.c_double),
-                                          ctypes.POINTER(ctypes.c_double),
-                                          ctypes.c_double,
-                                          ctypes.c_double,
-                                          ctypes.c_uint32,
-                                          ctypes.POINTER(
-                                              ctypes.POINTER(ctypes.c_void_p)),
-                                          ctypes.POINTER(ctypes.c_uint64)]
+    rt.Index_TPIntersects_obj.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_double,
+        ctypes.c_double,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+        ctypes.POINTER(ctypes.c_uint64),
+    ]
     rt.Index_TPIntersects_obj.restype = ctypes.c_int
     rt.Index_TPIntersects_obj.errcheck = check_return
 
-    rt.Index_TPIntersects_count.argtypes = [ctypes.c_void_p,
-                                            ctypes.POINTER(ctypes.c_double),
-                                            ctypes.POINTER(ctypes.c_double),
-                                            ctypes.POINTER(ctypes.c_double),
-                                            ctypes.POINTER(ctypes.c_double),
-                                            ctypes.c_double,
-                                            ctypes.c_double,
-                                            ctypes.c_uint32,
-                                            ctypes.POINTER(ctypes.c_uint64)]
+    rt.Index_TPIntersects_count.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_double,
+        ctypes.c_double,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_uint64),
+    ]
 
     rt.Index_TPNearestNeighbors_id.argtypes = [
         ctypes.c_void_p,
@@ -602,9 +619,9 @@ try:
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_uint32,
-        ctypes.POINTER(
-            ctypes.POINTER(ctypes.c_int64)),
-        ctypes.POINTER(ctypes.c_uint64)]
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_int64)),
+        ctypes.POINTER(ctypes.c_uint64),
+    ]
     rt.Index_TPNearestNeighbors_id.restype = ctypes.c_int
     rt.Index_TPNearestNeighbors_id.errcheck = check_return
 
@@ -617,9 +634,9 @@ try:
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_uint32,
-        ctypes.POINTER(
-            ctypes.POINTER(ctypes.c_void_p)),
-        ctypes.POINTER(ctypes.c_uint64)]
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+        ctypes.POINTER(ctypes.c_uint64),
+    ]
     rt.Index_TPNearestNeighbors_obj.restype = ctypes.c_int
     rt.Index_TPNearestNeighbors_obj.errcheck = check_return
 except AttributeError:

--- a/rtree/exceptions.py
+++ b/rtree/exceptions.py
@@ -1,4 +1,3 @@
-
 class RTreeError(Exception):
     "RTree exception, indicates a RTree-related error."
     pass

--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -4,23 +4,23 @@ finder.py
 
 Locate `libspatialindex` shared library by any means necessary.
 """
-import os
-import sys
 import ctypes
+import os
 import platform
+import sys
 from ctypes.util import find_library
 
 # the current working directory of this file
-_cwd = os.path.abspath(os.path.expanduser(
-    os.path.dirname(__file__)))
+_cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
 
 # generate a bunch of candidate locations where the
 # libspatialindex shared library *might* be hanging out
 _candidates = [
-    os.environ.get('SPATIALINDEX_C_LIBRARY', None),
-    os.path.join(_cwd, 'lib'),
+    os.environ.get("SPATIALINDEX_C_LIBRARY", None),
+    os.path.join(_cwd, "lib"),
     _cwd,
-    '']
+    "",
+]
 
 
 def load():
@@ -32,28 +32,27 @@ def load():
     rt : ctypes object
       Loaded shared library
     """
-    if os.name == 'nt':
+    if os.name == "nt":
         # check the platform architecture
-        if '64' in platform.architecture()[0]:
-            arch = '64'
+        if "64" in platform.architecture()[0]:
+            arch = "64"
         else:
-            arch = '32'
-        lib_name = 'spatialindex_c-{}.dll'.format(arch)
+            arch = "32"
+        lib_name = "spatialindex_c-{}.dll".format(arch)
 
         # add search paths for conda installs
-        if 'conda' in sys.version:
-            _candidates.append(
-                os.path.join(sys.prefix, "Library", "bin"))
+        if "conda" in sys.version:
+            _candidates.append(os.path.join(sys.prefix, "Library", "bin"))
 
         # get the current PATH
-        oldenv = os.environ.get('PATH', '').strip().rstrip(';')
+        oldenv = os.environ.get("PATH", "").strip().rstrip(";")
         # run through our list of candidate locations
         for path in _candidates:
             if not path or not os.path.exists(path):
                 continue
             # temporarily add the path to the PATH environment variable
             # so Windows can find additional DLL dependencies.
-            os.environ['PATH'] = ';'.join([path, oldenv])
+            os.environ["PATH"] = ";".join([path, oldenv])
             try:
                 rt = ctypes.cdll.LoadLibrary(os.path.join(path, lib_name))
                 if rt is not None:
@@ -61,21 +60,21 @@ def load():
             except (WindowsError, OSError):
                 pass
             except BaseException as E:
-                print('rtree.finder unexpected error: {}'.format(str(E)))
+                print("rtree.finder unexpected error: {}".format(str(E)))
             finally:
-                os.environ['PATH'] = oldenv
+                os.environ["PATH"] = oldenv
         raise OSError("could not find or load {}".format(lib_name))
 
-    elif os.name == 'posix':
+    elif os.name == "posix":
 
         # posix includes both mac and linux
         # use the extension for the specific platform
-        if platform.system() == 'Darwin':
+        if platform.system() == "Darwin":
             # macos shared libraries are `.dylib`
             lib_name = "libspatialindex_c.dylib"
         else:
             # linux shared libraries are `.so`
-            lib_name = 'libspatialindex_c.so'
+            lib_name = "libspatialindex_c.so"
 
         # get the starting working directory
         cwd = os.getcwd()
@@ -104,14 +103,13 @@ def load():
                 if rt is not None:
                     return rt
             except BaseException as E:
-                print('rtree.finder ({}) unexpected error: {}'.format(
-                    target, str(E)))
+                print("rtree.finder ({}) unexpected error: {}".format(target, str(E)))
             finally:
                 os.chdir(cwd)
 
     try:
         # try loading library using LD path search
-        path = find_library('spatialindex_c')
+        path = find_library("spatialindex_c")
         if path is not None:
             return ctypes.cdll.LoadLibrary(path)
 

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
-from liblas import file
 import sys
-from rtree import index
 
 import ogr
+from liblas import file
+
+from rtree import index
 
 
 def quick_create_layer_def(lyr, field_list):
@@ -31,34 +32,23 @@ def quick_create_layer_def(lyr, field_list):
         field_defn.Destroy()
 
 
-shape_drv = ogr.GetDriverByName('ESRI Shapefile')
+shape_drv = ogr.GetDriverByName("ESRI Shapefile")
 
-shapefile_name = sys.argv[1].split('.')[0]
+shapefile_name = sys.argv[1].split(".")[0]
 shape_ds = shape_drv.CreateDataSource(shapefile_name)
-leaf_block_lyr = shape_ds.CreateLayer('leaf', geom_type=ogr.wkbPolygon)
-point_block_lyr = shape_ds.CreateLayer('point', geom_type=ogr.wkbPolygon)
-point_lyr = shape_ds.CreateLayer('points', geom_type=ogr.wkbPoint)
+leaf_block_lyr = shape_ds.CreateLayer("leaf", geom_type=ogr.wkbPolygon)
+point_block_lyr = shape_ds.CreateLayer("point", geom_type=ogr.wkbPolygon)
+point_lyr = shape_ds.CreateLayer("points", geom_type=ogr.wkbPoint)
 
 quick_create_layer_def(
-    leaf_block_lyr,
-    [
-        ('BLK_ID', ogr.OFTInteger),
-        ('COUNT', ogr.OFTInteger),
-    ])
+    leaf_block_lyr, [("BLK_ID", ogr.OFTInteger), ("COUNT", ogr.OFTInteger)]
+)
 
 quick_create_layer_def(
-    point_block_lyr,
-    [
-        ('BLK_ID', ogr.OFTInteger),
-        ('COUNT', ogr.OFTInteger),
-    ])
+    point_block_lyr, [("BLK_ID", ogr.OFTInteger), ("COUNT", ogr.OFTInteger)]
+)
 
-quick_create_layer_def(
-    point_lyr,
-    [
-        ('ID', ogr.OFTInteger),
-        ('BLK_ID', ogr.OFTInteger),
-    ])
+quick_create_layer_def(point_lyr, [("ID", ogr.OFTInteger), ("BLK_ID", ogr.OFTInteger)])
 
 p = index.Property()
 p.filename = sys.argv[1]
@@ -98,10 +88,10 @@ def get_bounds(leaf_ids, lasfile, block_id):
         miny = min(miny, p.y)
         maxy = max(maxy, p.y)
         feature = ogr.Feature(feature_def=point_lyr.GetLayerDefn())
-        g = ogr.CreateGeometryFromWkt('POINT (%.8f %.8f)' % (p.x, p.y))
+        g = ogr.CreateGeometryFromWkt("POINT (%.8f %.8f)" % (p.x, p.y))
         feature.SetGeometry(g)
-        feature.SetField('ID', p_id)
-        feature.SetField('BLK_ID', block_id)
+        feature.SetField("ID", p_id)
+        feature.SetField("BLK_ID", block_id)
         result = point_lyr.CreateFeature(feature)
         del result
 
@@ -109,8 +99,18 @@ def get_bounds(leaf_ids, lasfile, block_id):
 
 
 def make_poly(minx, miny, maxx, maxy):
-    wkt = 'POLYGON ((%.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f))'\
-        % (minx, miny, maxx, miny, maxx, maxy, minx, maxy, minx, miny)
+    wkt = "POLYGON ((%.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f))" % (
+        minx,
+        miny,
+        maxx,
+        miny,
+        maxx,
+        maxy,
+        minx,
+        maxy,
+        minx,
+        miny,
+    )
     shp = ogr.CreateGeometryFromWkt(wkt)
     return shp
 
@@ -118,8 +118,8 @@ def make_poly(minx, miny, maxx, maxy):
 def make_feature(lyr, geom, id, count):
     feature = ogr.Feature(feature_def=lyr.GetLayerDefn())
     feature.SetGeometry(geom)
-    feature.SetField('BLK_ID', id)
-    feature.SetField('COUNT', count)
+    feature.SetField("BLK_ID", id)
+    feature.SetField("COUNT", count)
     result = lyr.CreateFeature(feature)
     del result
 
@@ -141,17 +141,15 @@ for leaf in leaves:
 
     print(leaf[2])
     leaf = make_poly(minx, miny, maxx, maxy)
-    print('leaf: ' + str([minx, miny, maxx, maxy]))
+    print("leaf: " + str([minx, miny, maxx, maxy]))
 
     pminx, pminy, pmaxx, pmaxy = get_bounds(ids, f, id)
     point = make_poly(pminx, pminy, pmaxx, pmaxy)
 
-    print('point: ' + str([pminx, pminy, pmaxx, pmaxy]))
-    print('point bounds: ' +
-          str([point.GetArea(), area(pminx, pminy, pmaxx, pmaxy)]))
-    print('leaf bounds: ' +
-          str([leaf.GetArea(), area(minx, miny, maxx, maxy)]))
-    print('leaf - point: ' + str([abs(point.GetArea() - leaf.GetArea())]))
+    print("point: " + str([pminx, pminy, pmaxx, pmaxy]))
+    print("point bounds: " + str([point.GetArea(), area(pminx, pminy, pmaxx, pmaxy)]))
+    print("leaf bounds: " + str([leaf.GetArea(), area(minx, miny, maxx, maxy)]))
+    print("leaf - point: " + str([abs(point.GetArea() - leaf.GetArea())]))
     print([minx, miny, maxx, maxy])
     #  if shp2.GetArea() != shp.GetArea():
     #      import pdb;pdb.set_trace()

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,9 @@
 import os
 
 from setuptools import setup
-from setuptools.dist import Distribution
 from setuptools.command.install import install
-
+from setuptools.dist import Distribution
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-
 
 # current working directory of this setup.py file
 _cwd = os.path.abspath(os.path.split(__file__)[0])
@@ -20,6 +18,7 @@ class bdist_wheel(_bdist_wheel):
 
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name"""
+
     def has_ext_modules(foo):
         return True
 
@@ -42,14 +41,12 @@ class InstallPlatlib(install):
         # get the location of the shared library on the filesystem
 
         # where we're putting the shared library in the build directory
-        target_dir = os.path.join(self.build_lib, 'rtree', 'lib')
+        target_dir = os.path.join(self.build_lib, "rtree", "lib")
         # where are we checking for shared libraries
-        source_dir = os.path.join(_cwd, 'rtree', 'lib')
+        source_dir = os.path.join(_cwd, "rtree", "lib")
 
         # what patterns represent shared libraries
-        patterns = {'*.so',
-                    'libspatialindex*dylib',
-                    '*.dll'}
+        patterns = {"*.so", "libspatialindex*dylib", "*.dll"}
 
         if not os.path.isdir(source_dir):
             # no copying of binary parts to library
@@ -75,11 +72,11 @@ class InstallPlatlib(install):
 
             # copy the source file to the target directory
             self.copy_file(
-                os.path.join(source_dir, file_name),
-                os.path.join(target_dir, file_name))
+                os.path.join(source_dir, file_name), os.path.join(target_dir, file_name)
+            )
 
 
 setup(
     distclass=BinaryDistribution,
-    cmdclass={'bdist_wheel': bdist_wheel, 'install': InstallPlatlib},
+    cmdclass={"bdist_wheel": bdist_wheel, "install": InstallPlatlib},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,7 @@ import shutil
 
 import pytest
 
-
-data_files = [
-    'boxes_15x15.data',
-]
+data_files = ["boxes_15x15.data"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,13 +1,14 @@
-import sys
-import unittest
 import ctypes
-import rtree
+import pickle
+import sys
+import tempfile
+import unittest
+
 import numpy as np
 import pytest
-import tempfile
-import pickle
 
-from rtree import index, core
+import rtree
+from rtree import core, index
 
 # is this running on Python 3
 PY3 = sys.version_info.major >= 3
@@ -15,13 +16,13 @@ PY3 = sys.version_info.major >= 3
 
 class IndexTestCase(unittest.TestCase):
     def setUp(self):
-        self.boxes15 = np.genfromtxt('boxes_15x15.data')
+        self.boxes15 = np.genfromtxt("boxes_15x15.data")
         self.idx = index.Index()
         for i, coords in enumerate(self.boxes15):
             self.idx.add(i, coords)
 
     def boxes15_stream(self, interleaved=True):
-        boxes15 = np.genfromtxt('boxes_15x15.data')
+        boxes15 = np.genfromtxt("boxes_15x15.data")
         for i, (minx, miny, maxx, maxy) in enumerate(boxes15):
 
             if interleaved:
@@ -34,21 +35,20 @@ class IndexTestCase(unittest.TestCase):
         # so do a very simple index check
         rtree_test = rtree.index.Index(
             [(1564, [0, 0, 0, 10, 10, 10], None)],
-            properties=rtree.index.Property(dimension=3))
+            properties=rtree.index.Property(dimension=3),
+        )
         assert next(rtree_test.intersection([1, 1, 1, 2, 2, 2])) == 1564
 
 
 class IndexVersion(unittest.TestCase):
-
     def test_libsidx_version(self):
         self.assertTrue(index.major_version == 1)
         self.assertTrue(index.minor_version >= 7)
 
 
 class IndexCount(unittest.TestCase):
-
     def setUp(self):
-        self.boxes15 = np.genfromtxt('boxes_15x15.data')
+        self.boxes15 = np.genfromtxt("boxes_15x15.data")
         self.idx = index.Index()
         for i, coords in enumerate(self.boxes15):
             self.idx.add(i, coords)
@@ -62,31 +62,29 @@ class IndexCount(unittest.TestCase):
 
 
 class IndexBounds(unittest.TestCase):
-
     def test_invalid_specifications(self):
         """Invalid specifications of bounds properly throw"""
 
         idx = index.Index()
-        self.assertRaises(core.RTreeError, idx.add,
-                          None, (0.0, 0.0, -1.0, 1.0))
-        self.assertRaises(core.RTreeError, idx.intersection,
-                          (0.0, 0.0, -1.0, 1.0))
-        self.assertRaises(ctypes.ArgumentError, idx.add, None, (1, 1,))
+        self.assertRaises(core.RTreeError, idx.add, None, (0.0, 0.0, -1.0, 1.0))
+        self.assertRaises(core.RTreeError, idx.intersection, (0.0, 0.0, -1.0, 1.0))
+        self.assertRaises(ctypes.ArgumentError, idx.add, None, (1, 1))
 
 
 class IndexProperties(IndexTestCase):
-
     @pytest.mark.skipif(
-        not hasattr(core.rt, 'Index_GetResultSetOffset'),
-        reason="Index_GetResultsSetOffset required in libspatialindex")
+        not hasattr(core.rt, "Index_GetResultSetOffset"),
+        reason="Index_GetResultsSetOffset required in libspatialindex",
+    )
     def test_result_offset(self):
         idx = index.Rtree()
         idx.set_result_offset(3)
         self.assertEqual(idx.result_offset, 3)
 
     @pytest.mark.skipif(
-        not hasattr(core.rt, 'Index_GetResultSetLimit'),
-        reason="Index_GetResultsSetOffset required in libspatialindex")
+        not hasattr(core.rt, "Index_GetResultSetLimit"),
+        reason="Index_GetResultsSetOffset required in libspatialindex",
+    )
     def test_result_limit(self):
         idx = index.Rtree()
         idx.set_result_limit(44)
@@ -130,8 +128,8 @@ class IndexProperties(IndexTestCase):
         p.writethrough = True
         p.tpr_horizon = 20.0
         p.reinsert_factor = 0.3
-        p.idx_extension = 'index'
-        p.dat_extension = 'data'
+        p.idx_extension = "index"
+        p.dat_extension = "data"
 
         idx = index.Index(properties=p)
 
@@ -153,18 +151,16 @@ class IndexProperties(IndexTestCase):
         self.assertEqual(props.writethrough, True)
         self.assertEqual(props.tpr_horizon, 20.0)
         self.assertEqual(props.reinsert_factor, 0.3)
-        self.assertEqual(props.idx_extension, 'index')
-        self.assertEqual(props.dat_extension, 'data')
+        self.assertEqual(props.idx_extension, "index")
+        self.assertEqual(props.dat_extension, "data")
 
 
 class TestPickling(unittest.TestCase):
-
     def test_index(self):
         idx = rtree.index.Index()
         unpickled = pickle.loads(pickle.dumps(idx))
         self.assertNotEqual(idx.handle, unpickled.handle)
-        self.assertEqual(idx.properties.as_dict(),
-                         unpickled.properties.as_dict())
+        self.assertEqual(idx.properties.as_dict(), unpickled.properties.as_dict())
         self.assertEqual(idx.interleaved, unpickled.interleaved)
 
     def test_property(self):
@@ -175,7 +171,6 @@ class TestPickling(unittest.TestCase):
 
 
 class IndexContainer(IndexTestCase):
-
     def test_container(self):
         """rtree.index.RtreeContainer works as expected"""
 
@@ -233,7 +228,6 @@ class IndexContainer(IndexTestCase):
 
 
 class IndexIntersection(IndexTestCase):
-
     def test_intersection(self):
         """Test basic insertion and retrieval"""
 
@@ -250,22 +244,14 @@ class IndexIntersection(IndexTestCase):
         for i, coords in enumerate(self.boxes15):
             idx.add(i, coords)
         idx.insert(
-            4321,
-            (34.3776829412,
-             26.7375853734,
-             49.3776829412,
-             41.7375853734),
-            obj=42)
+            4321, (34.3776829412, 26.7375853734, 49.3776829412, 41.7375853734), obj=42
+        )
         hits = idx.intersection((0, 0, 60, 60), objects=True)
         hit = [h for h in hits if h.id == 4321][0]
         self.assertEqual(hit.id, 4321)
         self.assertEqual(hit.object, 42)
-        box = ['%.10f' % t for t in hit.bbox]
-        expected = [
-            '34.3776829412',
-            '26.7375853734',
-            '49.3776829412',
-            '41.7375853734']
+        box = ["%.10f" % t for t in hit.bbox]
+        expected = ["34.3776829412", "26.7375853734", "49.3776829412", "41.7375853734"]
         self.assertEqual(box, expected)
 
     def test_double_insertion(self):
@@ -278,9 +264,8 @@ class IndexIntersection(IndexTestCase):
 
 
 class IndexSerialization(unittest.TestCase):
-
     def setUp(self):
-        self.boxes15 = np.genfromtxt('boxes_15x15.data')
+        self.boxes15 = np.genfromtxt("boxes_15x15.data")
 
     def boxes15_stream(self, interleaved=True):
         for i, (minx, miny, maxx, maxy) in enumerate(self.boxes15):
@@ -294,15 +279,11 @@ class IndexSerialization(unittest.TestCase):
         if sys.version_info.major < 3:
             return
         tname = tempfile.mktemp()
-        filename = tname + u'gilename\u4500abc'
+        filename = tname + "gilename\u4500abc"
         idx = index.Index(filename)
         idx.insert(
-            4321,
-            (34.3776829412,
-             26.7375853734,
-             49.3776829412,
-             41.7375853734),
-            obj=42)
+            4321, (34.3776829412, 26.7375853734, 49.3776829412, 41.7375853734), obj=42
+        )
 
     def test_pickling(self):
         """Pickling works as expected"""
@@ -312,20 +293,17 @@ class IndexSerialization(unittest.TestCase):
 
         some_data = {"a": 22, "b": [1, "ccc"]}
 
-        idx.dumps = lambda obj: json.dumps(obj).encode('utf-8')
-        idx.loads = lambda string: json.loads(string.decode('utf-8'))
+        idx.dumps = lambda obj: json.dumps(obj).encode("utf-8")
+        idx.loads = lambda string: json.loads(string.decode("utf-8"))
         idx.add(0, (0, 0, 1, 1), some_data)
 
-        self.assertEqual(
-            list(
-                idx.nearest(
-                    (0, 0), 1, objects="raw"))[0], some_data)
+        self.assertEqual(list(idx.nearest((0, 0), 1, objects="raw"))[0], some_data)
 
     def test_custom_filenames(self):
         """Test using custom filenames for index serialization"""
         p = index.Property()
-        p.dat_extension = 'data'
-        p.idx_extension = 'index'
+        p.dat_extension = "data"
+        p.idx_extension = "index"
         tname = tempfile.mktemp()
         idx = index.Index(tname, properties=p)
         for i, coords in enumerate(self.boxes15):
@@ -344,39 +322,146 @@ class IndexSerialization(unittest.TestCase):
 
     def test_interleaving(self):
         """Streaming against a persisted index without interleaving"""
+
         def data_gen(interleaved=True):
             for i, (minx, miny, maxx, maxy) in enumerate(self.boxes15):
                 if interleaved:
                     yield (i, (minx, miny, maxx, maxy), 42)
                 else:
                     yield (i, (minx, maxx, miny, maxy), 42)
+
         p = index.Property()
         tname = tempfile.mktemp()
-        idx = index.Index(tname,
-                          data_gen(interleaved=False),
-                          properties=p,
-                          interleaved=False)
+        idx = index.Index(
+            tname, data_gen(interleaved=False), properties=p, interleaved=False
+        )
         hits = sorted(list(idx.intersection((0, 60, 0, 60))))
         self.assertTrue(len(hits), 10)
         self.assertEqual(hits, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
 
         leaves = idx.leaves()
         expected = [
-            (0, [2, 92, 51, 55, 26, 95, 7, 81, 38, 22, 58, 89, 91, 83, 98, 37,
-                 70, 31, 49, 34, 11, 6, 13, 3, 23, 57, 9, 96, 84, 36, 5, 45,
-                 77, 78, 44, 12, 42, 73, 93, 41, 71, 17, 39, 54, 88, 72, 97,
-                 60, 62, 48, 19, 25, 76, 59, 66, 64, 79, 94, 40, 32, 46, 47,
-                 15, 68, 10, 0, 80, 56, 50, 30],
-             [-186.673789279, -96.7177218184, 172.392784956, 45.4856075292]),
-            (2, [61, 74, 29, 99, 16, 43, 35, 33, 27, 63, 18, 90, 8, 53, 82,
-                 21, 65, 24, 4, 1, 75, 67, 86, 52, 28, 85, 87, 14, 69, 20],
-             [-174.739939684, 32.6596016791, 184.761387556, 96.6043699778])]
+            (
+                0,
+                [
+                    2,
+                    92,
+                    51,
+                    55,
+                    26,
+                    95,
+                    7,
+                    81,
+                    38,
+                    22,
+                    58,
+                    89,
+                    91,
+                    83,
+                    98,
+                    37,
+                    70,
+                    31,
+                    49,
+                    34,
+                    11,
+                    6,
+                    13,
+                    3,
+                    23,
+                    57,
+                    9,
+                    96,
+                    84,
+                    36,
+                    5,
+                    45,
+                    77,
+                    78,
+                    44,
+                    12,
+                    42,
+                    73,
+                    93,
+                    41,
+                    71,
+                    17,
+                    39,
+                    54,
+                    88,
+                    72,
+                    97,
+                    60,
+                    62,
+                    48,
+                    19,
+                    25,
+                    76,
+                    59,
+                    66,
+                    64,
+                    79,
+                    94,
+                    40,
+                    32,
+                    46,
+                    47,
+                    15,
+                    68,
+                    10,
+                    0,
+                    80,
+                    56,
+                    50,
+                    30,
+                ],
+                [-186.673789279, -96.7177218184, 172.392784956, 45.4856075292],
+            ),
+            (
+                2,
+                [
+                    61,
+                    74,
+                    29,
+                    99,
+                    16,
+                    43,
+                    35,
+                    33,
+                    27,
+                    63,
+                    18,
+                    90,
+                    8,
+                    53,
+                    82,
+                    21,
+                    65,
+                    24,
+                    4,
+                    1,
+                    75,
+                    67,
+                    86,
+                    52,
+                    28,
+                    85,
+                    87,
+                    14,
+                    69,
+                    20,
+                ],
+                [-174.739939684, 32.6596016791, 184.761387556, 96.6043699778],
+            ),
+        ]
 
         if PY3 and False:
             # TODO : this reliably fails on Python 2.7 and 3.5
             # go through the traversal and see if everything is close
-            assert all(all(np.allclose(a, b) for a, b in zip(L, E))
-                       for L, E in zip(leaves, expected))
+            assert all(
+                all(np.allclose(a, b) for a, b in zip(L, E))
+                for L, E in zip(leaves, expected)
+            )
 
         hits = sorted(list(idx.intersection((0, 60, 0, 60), objects=True)))
         self.assertTrue(len(hits), 10)
@@ -393,7 +478,6 @@ class IndexSerialization(unittest.TestCase):
 
 
 class IndexNearest(IndexTestCase):
-
     def test_nearest_basic(self):
         """Test nearest basic selection of records"""
         hits = list(self.idx.nearest((0, 0, 10, 10), 3))
@@ -444,16 +528,15 @@ class IndexNearest(IndexTestCase):
         idx = index.Index()
         locs = [(14, 10, 14, 10), (16, 10, 16, 10)]
         for i, (minx, miny, maxx, maxy) in enumerate(locs):
-            idx.add(i, (minx, miny, maxx, maxy), obj={'a': 42})
+            idx.add(i, (minx, miny, maxx, maxy), obj={"a": 42})
 
         hits = sorted(
-            [(i.id, i.object)
-             for i in idx.nearest((15, 10, 15, 10), 1, objects=True)])
-        self.assertEqual(hits, [(0, {'a': 42}), (1, {'a': 42})])
+            [(i.id, i.object) for i in idx.nearest((15, 10, 15, 10), 1, objects=True)]
+        )
+        self.assertEqual(hits, [(0, {"a": 42}), (1, {"a": 42})])
 
 
 class IndexDelete(IndexTestCase):
-
     def test_deletion(self):
         """Test we can delete data from the index"""
         idx = index.Index()
@@ -488,7 +571,6 @@ class IndexMoreDimensions(IndexTestCase):
 
 
 class IndexStream(IndexTestCase):
-
     def test_stream_input(self):
         p = index.Property()
         sindex = index.Index(self.boxes15_stream(), properties=p)
@@ -506,6 +588,7 @@ class IndexStream(IndexTestCase):
 
     def test_exception_in_generator(self):
         """Assert exceptions raised in callbacks are raised in main thread"""
+
         class TestException(Exception):
             pass
 
@@ -515,6 +598,7 @@ class IndexStream(IndexTestCase):
                 for i in range(10):
                     yield (i, (1, 2, 3, 4), None)
                 raise TestException("raising here")
+
             return index.Index(gen())
 
         self.assertRaises(TestException, create_index)
@@ -524,6 +608,7 @@ class IndexStream(IndexTestCase):
         Assert exceptions raised in callbacks before generator
         function are raised in main thread.
         """
+
         class TestException(Exception):
             pass
 
@@ -531,37 +616,38 @@ class IndexStream(IndexTestCase):
             def gen():
 
                 raise TestException("raising here")
+
             return index.Index(gen())
 
         self.assertRaises(TestException, create_index)
 
 
 class DictStorage(index.CustomStorage):
-    """ A simple storage which saves the pages in a python dictionary """
+    """A simple storage which saves the pages in a python dictionary"""
 
     def __init__(self):
         index.CustomStorage.__init__(self)
         self.clear()
 
     def create(self, returnError):
-        """ Called when the storage is created on the C side """
+        """Called when the storage is created on the C side"""
 
     def destroy(self, returnError):
-        """ Called when the storage is destroyed on the C side """
+        """Called when the storage is destroyed on the C side"""
 
     def clear(self):
-        """ Clear all our data """
+        """Clear all our data"""
         self.dict = {}
 
     def loadByteArray(self, page, returnError):
-        """ Returns the data for page or returns an error """
+        """Returns the data for page or returns an error"""
         try:
             return self.dict[page]
         except KeyError:
             returnError.contents.value = self.InvalidPageError
 
     def storeByteArray(self, page, data, returnError):
-        """ Stores the data for page """
+        """Stores the data for page"""
         if page == self.NewPage:
             newPageId = len(self.dict)
             self.dict[newPageId] = data
@@ -574,7 +660,7 @@ class DictStorage(index.CustomStorage):
             return page
 
     def deleteByteArray(self, page, returnError):
-        """ Deletes a page """
+        """Deletes a page"""
         try:
             del self.dict[page]
         except KeyError:


### PR DESCRIPTION
This PR uses `black` and `isort` to auto-format the repo. These tools are developed by PSF and PyCQA and used by many projects to enforce a common PEP-8 compliant standard. Unlike `flake8`, these tools are auto-formatters, so if someone submits a PR that doesn't pass these tests, they simply need to run `black .` or `isort .` in the repo and it will solve all of their issues. This was incredibly useful when working on #215 since the type hints I added increased the line length of most function signatures above the 88 character limit. Downside is that `git blame` is much less useful now since this PR affects most files. But the same will be true with #215 since it edits every function signature.