### PR TITLE
Mypy: fix type hints for doc list

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,7 +135,7 @@ html_theme = "nature"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path: List[str] = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
This list was modified in #219, resulting in the need for type hints. But #215 was merged at the same time, before type hints were required. Now that both PRs have been merged, the mypy tests are failing without this.