### PR TITLE
Fix C API mismatches vs. libspatialindex

### DIFF
--- a/rtree/core.py
+++ b/rtree/core.py
@@ -99,7 +99,7 @@ NEXTFUNC = ctypes.CFUNCTYPE(
     ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
     ctypes.POINTER(ctypes.c_uint32),
     ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
-    ctypes.POINTER(ctypes.c_uint32),
+    ctypes.POINTER(ctypes.c_size_t),
 )
 
 rt.Index_CreateWithStream.argtypes = [ctypes.c_void_p, NEXTFUNC]

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -73,12 +73,14 @@ def free_error_msg_ptr(result, func, cargs):
 # load the shared library by looking in likely places
 rt = finder.load()
 
+rt.Error_GetLastErrorNum.argtypes = []
 rt.Error_GetLastErrorNum.restype = ctypes.c_int
 
 rt.Error_GetLastErrorMsg.argtypes = []
 rt.Error_GetLastErrorMsg.restype = ctypes.POINTER(ctypes.c_char)
 rt.Error_GetLastErrorMsg.errcheck = free_error_msg_ptr  # type: ignore
 
+rt.Error_GetLastErrorMethod.argtypes = []
 rt.Error_GetLastErrorMethod.restype = ctypes.POINTER(ctypes.c_char)
 rt.Error_GetLastErrorMethod.errcheck = free_returned_char_p  # type: ignore
 

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -323,7 +323,7 @@ rt.IndexProperty_SetDimension.restype = ctypes.c_int
 rt.IndexProperty_SetDimension.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetDimension.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetDimension.restype = ctypes.c_int
+rt.IndexProperty_GetDimension.restype = ctypes.c_uint32
 rt.IndexProperty_GetDimension.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetIndexVariant.argtypes = [ctypes.c_void_p, ctypes.c_int]
@@ -347,7 +347,7 @@ rt.IndexProperty_SetIndexCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetIndexCapacity.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetIndexCapacity.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetIndexCapacity.restype = ctypes.c_int
+rt.IndexProperty_GetIndexCapacity.restype = ctypes.c_uint32
 rt.IndexProperty_GetIndexCapacity.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetLeafCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -355,7 +355,7 @@ rt.IndexProperty_SetLeafCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetLeafCapacity.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetLeafCapacity.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetLeafCapacity.restype = ctypes.c_int
+rt.IndexProperty_GetLeafCapacity.restype = ctypes.c_uint32
 rt.IndexProperty_GetLeafCapacity.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetPagesize.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -363,7 +363,7 @@ rt.IndexProperty_SetPagesize.restype = ctypes.c_int
 rt.IndexProperty_SetPagesize.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetPagesize.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetPagesize.restype = ctypes.c_int
+rt.IndexProperty_GetPagesize.restype = ctypes.c_uint32
 rt.IndexProperty_GetPagesize.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetLeafPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -371,7 +371,7 @@ rt.IndexProperty_SetLeafPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetLeafPoolCapacity.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetLeafPoolCapacity.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetLeafPoolCapacity.restype = ctypes.c_int
+rt.IndexProperty_GetLeafPoolCapacity.restype = ctypes.c_uint32
 rt.IndexProperty_GetLeafPoolCapacity.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetIndexPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -379,7 +379,7 @@ rt.IndexProperty_SetIndexPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetIndexPoolCapacity.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetIndexPoolCapacity.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetIndexPoolCapacity.restype = ctypes.c_int
+rt.IndexProperty_GetIndexPoolCapacity.restype = ctypes.c_uint32
 rt.IndexProperty_GetIndexPoolCapacity.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetRegionPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -387,7 +387,7 @@ rt.IndexProperty_SetRegionPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetRegionPoolCapacity.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetRegionPoolCapacity.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetRegionPoolCapacity.restype = ctypes.c_int
+rt.IndexProperty_GetRegionPoolCapacity.restype = ctypes.c_uint32
 rt.IndexProperty_GetRegionPoolCapacity.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetPointPoolCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -395,7 +395,7 @@ rt.IndexProperty_SetPointPoolCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetPointPoolCapacity.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetPointPoolCapacity.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetPointPoolCapacity.restype = ctypes.c_int
+rt.IndexProperty_GetPointPoolCapacity.restype = ctypes.c_uint32
 rt.IndexProperty_GetPointPoolCapacity.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetBufferingCapacity.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -403,7 +403,7 @@ rt.IndexProperty_SetBufferingCapacity.restype = ctypes.c_int
 rt.IndexProperty_SetBufferingCapacity.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetBufferingCapacity.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetBufferingCapacity.restype = ctypes.c_int
+rt.IndexProperty_GetBufferingCapacity.restype = ctypes.c_uint32
 rt.IndexProperty_GetBufferingCapacity.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetEnsureTightMBRs.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -411,7 +411,7 @@ rt.IndexProperty_SetEnsureTightMBRs.restype = ctypes.c_int
 rt.IndexProperty_SetEnsureTightMBRs.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetEnsureTightMBRs.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetEnsureTightMBRs.restype = ctypes.c_int
+rt.IndexProperty_GetEnsureTightMBRs.restype = ctypes.c_uint32
 rt.IndexProperty_GetEnsureTightMBRs.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetOverwrite.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -419,7 +419,7 @@ rt.IndexProperty_SetOverwrite.restype = ctypes.c_int
 rt.IndexProperty_SetOverwrite.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetOverwrite.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetOverwrite.restype = ctypes.c_int
+rt.IndexProperty_GetOverwrite.restype = ctypes.c_uint32
 rt.IndexProperty_GetOverwrite.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetNearMinimumOverlapFactor.argtypes = [
@@ -430,7 +430,7 @@ rt.IndexProperty_SetNearMinimumOverlapFactor.restype = ctypes.c_int
 rt.IndexProperty_SetNearMinimumOverlapFactor.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetNearMinimumOverlapFactor.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetNearMinimumOverlapFactor.restype = ctypes.c_int
+rt.IndexProperty_GetNearMinimumOverlapFactor.restype = ctypes.c_uint32
 rt.IndexProperty_GetNearMinimumOverlapFactor.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetWriteThrough.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
@@ -438,7 +438,7 @@ rt.IndexProperty_SetWriteThrough.restype = ctypes.c_int
 rt.IndexProperty_SetWriteThrough.errcheck = check_return  # type: ignore
 
 rt.IndexProperty_GetWriteThrough.argtypes = [ctypes.c_void_p]
-rt.IndexProperty_GetWriteThrough.restype = ctypes.c_int
+rt.IndexProperty_GetWriteThrough.restype = ctypes.c_uint32
 rt.IndexProperty_GetWriteThrough.errcheck = check_value  # type: ignore
 
 rt.IndexProperty_SetFillFactor.argtypes = [ctypes.c_void_p, ctypes.c_double]

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -310,7 +310,7 @@ rt.IndexProperty_Destroy.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_Destroy.restype = None
 rt.IndexProperty_Destroy.errcheck = check_void_done  # type: ignore
 
-rt.IndexProperty_SetIndexType.argtypes = [ctypes.c_void_p, ctypes.c_int32]
+rt.IndexProperty_SetIndexType.argtypes = [ctypes.c_void_p, ctypes.c_int]
 rt.IndexProperty_SetIndexType.restype = ctypes.c_int
 rt.IndexProperty_SetIndexType.errcheck = check_return  # type: ignore
 
@@ -326,7 +326,7 @@ rt.IndexProperty_GetDimension.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetDimension.restype = ctypes.c_int
 rt.IndexProperty_GetDimension.errcheck = check_value  # type: ignore
 
-rt.IndexProperty_SetIndexVariant.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetIndexVariant.argtypes = [ctypes.c_void_p, ctypes.c_int]
 rt.IndexProperty_SetIndexVariant.restype = ctypes.c_int
 rt.IndexProperty_SetIndexVariant.errcheck = check_return  # type: ignore
 
@@ -334,7 +334,7 @@ rt.IndexProperty_GetIndexVariant.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetIndexVariant.restype = ctypes.c_int
 rt.IndexProperty_GetIndexVariant.errcheck = check_value  # type: ignore
 
-rt.IndexProperty_SetIndexStorage.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+rt.IndexProperty_SetIndexStorage.argtypes = [ctypes.c_void_p, ctypes.c_int]
 rt.IndexProperty_SetIndexStorage.restype = ctypes.c_int
 rt.IndexProperty_SetIndexStorage.errcheck = check_return  # type: ignore
 

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -527,7 +527,7 @@ rt.IndexProperty_GetIndexID.argtypes = [ctypes.c_void_p]
 rt.IndexProperty_GetIndexID.restype = ctypes.c_int64
 rt.IndexProperty_GetIndexID.errcheck = check_value  # type: ignore
 
-rt.SIDX_NewBuffer.argtypes = [ctypes.c_uint]
+rt.SIDX_NewBuffer.argtypes = [ctypes.c_size_t]
 rt.SIDX_NewBuffer.restype = ctypes.c_void_p
 rt.SIDX_NewBuffer.errcheck = check_void  # type: ignore
 
@@ -551,7 +551,7 @@ try:
         ctypes.c_double,
         ctypes.c_uint32,
         ctypes.POINTER(ctypes.c_ubyte),
-        ctypes.c_uint32,
+        ctypes.c_size_t,
     ]
     rt.Index_InsertTPData.restype = ctypes.c_int
     rt.Index_InsertTPData.errcheck = check_return  # type: ignore

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -611,6 +611,8 @@ try:
         ctypes.c_uint32,
         ctypes.POINTER(ctypes.c_uint64),
     ]
+    rt.Index_TPIntersects_count.restype = ctypes.c_int
+    rt.Index_TPIntersects_count.errcheck = check_return  # type: ignore
 
     rt.Index_TPNearestNeighbors_id.argtypes = [
         ctypes.c_void_p,


### PR DESCRIPTION
This fixes #220 by correcting the mismatches with the `libspatialindex` API that were noted in that issue and its comments.