### PR TITLE
Apply pyupgrade --py37-plus --keep-runtime-typing, with mods

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Rtree documentation build configuration file, created by
 # sphinx-quickstart on Tue Aug 18 13:21:07 2009.

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -8,7 +8,7 @@ def check_return(result, func, cargs):
     "Error checking for Error calls"
     if result != 0:
         s = rt.Error_GetLastErrorMsg().decode()
-        msg = 'LASError in "%s": %s' % (func.__name__, s)
+        msg = f'Error in "{func.__name__}": {s}'
         rt.Error_Reset()
         raise RTreeError(msg)
     return True
@@ -18,7 +18,7 @@ def check_void(result, func, cargs):
     "Error checking for void* returns"
     if not bool(result):
         s = rt.Error_GetLastErrorMsg().decode()
-        msg = 'Error in "%s": %s' % (func.__name__, s)
+        msg = f'Error in "{func.__name__}": {s}'
         rt.Error_Reset()
         raise RTreeError(msg)
     return result
@@ -28,7 +28,7 @@ def check_void_done(result, func, cargs):
     "Error checking for void* returns that might be empty with no error"
     if rt.Error_GetErrorCount():
         s = rt.Error_GetLastErrorMsg().decode()
-        msg = 'Error in "%s": %s' % (func.__name__, s)
+        msg = f'Error in "{func.__name__}": {s}'
         rt.Error_Reset()
         raise RTreeError(msg)
     return result
@@ -39,7 +39,7 @@ def check_value(result, func, cargs):
     count = rt.Error_GetErrorCount()
     if count != 0:
         s = rt.Error_GetLastErrorMsg().decode()
-        msg = 'Error in "%s": %s' % (func.__name__, s)
+        msg = f'Error in "{func.__name__}": {s}'
         rt.Error_Reset()
         raise RTreeError(msg)
     return result
@@ -50,7 +50,7 @@ def check_value_free(result, func, cargs):
     count = rt.Error_GetErrorCount()
     if count != 0:
         s = rt.Error_GetLastErrorMsg().decode()
-        msg = 'Error in "%s": %s' % (func.__name__, s)
+        msg = f'Error in "{func.__name__}": {s}'
         rt.Error_Reset()
         raise RTreeError(msg)
     return result

--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -34,7 +34,7 @@ def load() -> ctypes.CDLL:
             arch = "64"
         else:
             arch = "32"
-        lib_name = "spatialindex_c-{}.dll".format(arch)
+        lib_name = f"spatialindex_c-{arch}.dll"
 
         # add search paths for conda installs
         if "conda" in sys.version:
@@ -56,10 +56,10 @@ def load() -> ctypes.CDLL:
             except OSError:
                 pass
             except BaseException as E:
-                print("rtree.finder unexpected error: {}".format(str(E)))
+                print(f"rtree.finder unexpected error: {E!s}")
             finally:
                 os.environ["PATH"] = oldenv
-        raise OSError("could not find or load {}".format(lib_name))
+        raise OSError(f"could not find or load {lib_name}")
 
     elif os.name == "posix":
 
@@ -99,7 +99,7 @@ def load() -> ctypes.CDLL:
                 if rt is not None:
                     return rt
             except BaseException as E:
-                print("rtree.finder ({}) unexpected error: {}".format(target, str(E)))
+                print(f"rtree.finder ({target}) unexpected error: {E!s}")
             finally:
                 os.chdir(cwd)
 

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -31,9 +31,9 @@ RT_TPRTree = 2
 
 __c_api_version__ = core.rt.SIDX_Version()
 
-major_version, minor_version, patch_version = [
+major_version, minor_version, patch_version = (
     int(t) for t in __c_api_version__.decode("utf-8").split(".")
-]
+)
 
 if (major_version, minor_version, patch_version) < (1, 8, 5):
     raise Exception("Rtree requires libspatialindex 1.8.5 or greater")
@@ -329,7 +329,7 @@ class Index:
             self.handle.destroy()
             self.handle = None
         else:
-            raise IOError("Unclosable index")
+            raise OSError("Unclosable index")
 
     def flush(self) -> None:
         """Force a flush of the index to storage."""
@@ -2057,7 +2057,7 @@ class RtreeContainer(Rtree):
             ):
                 raise ValueError("%s supports only in-memory indexes" % self.__class__)
         self._objects: Dict[int, Tuple[int, object]] = {}
-        return super(RtreeContainer, self).__init__(*args, **kwargs)
+        return super().__init__(*args, **kwargs)
 
     def get_size(self) -> int:
         try:
@@ -2117,7 +2117,7 @@ class RtreeContainer(Rtree):
         except KeyError:
             count = 1
         self._objects[id(obj)] = (count, obj)
-        return super(RtreeContainer, self).insert(id(obj), coordinates, None)
+        return super().insert(id(obj), coordinates, None)
 
     add = insert  # type: ignore[assignment]
 
@@ -2190,10 +2190,10 @@ class RtreeContainer(Rtree):
 
         """
         if bbox is False:
-            for id in super(RtreeContainer, self).intersection(coordinates, bbox):
+            for id in super().intersection(coordinates, bbox):
                 yield self._objects[id][1]
         elif bbox is True:
-            for value in super(RtreeContainer, self).intersection(coordinates, bbox):
+            for value in super().intersection(coordinates, bbox):
                 value.object = self._objects[value.id][1]
                 value.id = None
                 yield value
@@ -2246,14 +2246,10 @@ class RtreeContainer(Rtree):
             >>> hits = idx.nearest((0, 0, 10, 10), 3, bbox=True)
         """
         if bbox is False:
-            for id in super(RtreeContainer, self).nearest(
-                coordinates, num_results, bbox
-            ):
+            for id in super().nearest(coordinates, num_results, bbox):
                 yield self._objects[id][1]
         elif bbox is True:
-            for value in super(RtreeContainer, self).nearest(
-                coordinates, num_results, bbox
-            ):
+            for value in super().nearest(coordinates, num_results, bbox):
                 value.object = self._objects[value.id][1]
                 value.id = None
                 yield value
@@ -2313,7 +2309,7 @@ class RtreeContainer(Rtree):
             del self._objects[id(obj)]
         else:
             self._objects[id(obj)] = (count, obj)
-        return super(RtreeContainer, self).delete(id(obj), coordinates)
+        return super().delete(id(obj), coordinates)
 
     def leaves(self):
         return [

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -88,7 +88,7 @@ def get_bounds(leaf_ids, lasfile, block_id):
         miny = min(miny, p.y)
         maxy = max(maxy, p.y)
         feature = ogr.Feature(feature_def=point_lyr.GetLayerDefn())
-        g = ogr.CreateGeometryFromWkt("POINT (%.8f %.8f)" % (p.x, p.y))
+        g = ogr.CreateGeometryFromWkt(f"POINT ({p.x:.8f} {p.y:.8f})")
         feature.SetGeometry(g)
         feature.SetField("ID", p_id)
         feature.SetField("BLK_ID", block_id)
@@ -99,17 +99,9 @@ def get_bounds(leaf_ids, lasfile, block_id):
 
 
 def make_poly(minx, miny, maxx, maxy):
-    wkt = "POLYGON ((%.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f, %.8f %.8f))" % (
-        minx,
-        miny,
-        maxx,
-        miny,
-        maxx,
-        maxy,
-        minx,
-        maxy,
-        minx,
-        miny,
+    wkt = (
+        f"POLYGON (({minx:.8f} {miny:.8f}, {maxx:.8f} {miny:.8f}, {maxx:.8f} "
+        f"{maxy:.8f}, {minx:.8f} {maxy:.8f}, {minx:.8f} {miny:.8f}))"
     )
     shp = ogr.CreateGeometryFromWkt(wkt)
     return shp

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -545,7 +545,7 @@ class IndexNearest(IndexTestCase):
             idx.add(i, (minx, miny, maxx, maxy), obj={"a": 42})
 
         hits = sorted(
-            [(i.id, i.object) for i in idx.nearest((15, 10, 15, 10), 1, objects=True)]
+            (i.id, i.object) for i in idx.nearest((15, 10, 15, 10), 1, objects=True)
         )
         self.assertEqual(hits, [(0, {"a": 42}), (1, {"a": 42})])
 


### PR DESCRIPTION
Modernize the code base to Python 3.7+ using [pyupgrade](https://github.com/asottile/pyupgrade) with a few manual modifications for string formatting. Also change a message with "LASError" (from libLAS) to simply "Error".

The initial command was:
```
pyupgrade --py37-plus --keep-runtime-typing `find . -name "*.py"`
```