### PR TITLE
Add xfail test for pickling

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -157,12 +157,22 @@ class IndexProperties(IndexTestCase):
 
 
 class TestPickling(unittest.TestCase):
+    # https://github.com/Toblerity/rtree/issues/87
+    @pytest.mark.xfail
     def test_index(self) -> None:
         idx = rtree.index.Index()
+        idx.insert(0, [0, 1, 2, 3], 4)
         unpickled = pickle.loads(pickle.dumps(idx))
         self.assertNotEqual(idx.handle, unpickled.handle)
         self.assertEqual(idx.properties.as_dict(), unpickled.properties.as_dict())
         self.assertEqual(idx.interleaved, unpickled.interleaved)
+        self.assertEqual(len(idx), len(unpickled))
+        self.assertEqual(idx.bounds, unpickled.bounds)
+        a = next(idx.intersection(idx.bounds, objects=True))
+        b = next(unpickled.intersection(unpickled.bounds, objects=True))
+        self.assertEqual(a.id, b.id)
+        self.assertEqual(a.bounds, b.bounds)
+        self.assertEqual(a.object, b.object)
 
     def test_property(self) -> None:
         p = rtree.index.Property()


### PR DESCRIPTION
This PR adds the tests from #197 so we can at least properly test index pickling. This test is marked as xfail since rtree indices currently can't be pickled without losing all contents. Hopefully this will make it easier to fix and test in the future.