### PR TITLE
Fixing could not find or load spatialindex_c-64.dll with conda (#191)

### DIFF
--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -37,8 +37,7 @@ def load() -> ctypes.CDLL:
         lib_name = f"spatialindex_c-{arch}.dll"
 
         # add search paths for conda installs
-        if "conda" in sys.version:
-            _candidates.append(os.path.join(sys.prefix, "Library", "bin"))
+        _candidates.append(os.path.join(sys.prefix, "Library", "bin"))
 
         # get the current PATH
         oldenv = os.environ.get("PATH", "").strip().rstrip(";")


### PR DESCRIPTION
In the newer version of conda there is no longer `"conda" in sys.version`, unless you install python with -c conda-forge.