### PR TITLE
Update keyword argument in docs

### DIFF
--- a/docs/source/tutorial.txt
+++ b/docs/source/tutorial.txt
@@ -121,7 +121,7 @@ Rtree also supports inserting any object you can pickle into the index (called
 a clustered index in `libspatialindex`_ parlance). The following inserts the
 picklable object ``42`` into the index with the given id::
 
-  >>> idx.insert(id=id, bounds=(left, bottom, right, top), obj=42)
+  >>> idx.insert(id=id, coordinates=(left, bottom, right, top), obj=42)
 
 You can then return a list of objects by giving the ``objects=True`` flag
 to intersection::


### PR DESCRIPTION
I'm not sure when `Index.insert(...)` had "bounds" as a keyword argument, but it seems to be incorrect.

(although I feel like copy+pasting this line from the tutorial page has worked for me in the past at some point; no idea when)