### PR TITLE
Make Rtree PEP 561-compliant, so that Mypy finds type hints

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.md *.txt
 include MANIFEST.in
+include rtree/py.typed
 recursive-include tests *
 recursive-include docs *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include *.md *.txt
 include MANIFEST.in
-include rtree/py.typed
 recursive-include tests *
 recursive-include docs *

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_date = True
 packages = rtree
 
 [options.package_data]
-rtree = lib, py.typed
+rtree = lib
 
 [flake8]
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_date = True
 packages = rtree
 
 [options.package_data]
-rtree = lib
+rtree = lib, py.typed
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
After #215, I was excited to take advantage of type hints in my projects that
use Rtree. However, after upgrading to v1.0.0, mypy was giving [import
errors]. According to those docs, mypy will only infer/lookup types from
installed packages if they are [PEP 561] compliant.

Fortunately, all that seems to [involve] is the inclusion of a `py.typed` marker
file in the installed package. This PR is my attempt at doing just that. In my
local testing, this seems to resolve the above Mypy import warnings.

I'm new to setuptools and distributing sdist wheels though, so I'm not sure how
to confirm this file will be included in the built wheels? From reading the
[setuptools docs], I think this is right, but probably worth review from someone
who knows these things better.

[import errors]: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
[PEP 561]: https://peps.python.org/pep-0561/
[involve]: https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages
[setuptools docs]: https://setuptools.pypa.io/en/latest/userguide/datafiles.html