### PR TITLE
CI: Simplify wheel building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
       MACOSX_DEPLOYMENT_TARGET: 10.9
       CIBW_BUILD_VERBOSITY_MACOS: 3
-      CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-musllinux*"
+      CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-musllinux* *i686"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
       CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
@@ -186,10 +186,11 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.11.2
       env:
+        CIBW_SKIP: pp*
         CIBW_ARCHS_LINUX: aarch64
         CIBW_TEST_REQUIRES: pytest numpy
         CIBW_TEST_COMMAND: "pytest -v {project}/tests"
-        CIBW_TEST_SKIP: "cp37-* *-musllinux*"
+        CIBW_TEST_SKIP: "*-musllinux*"
         CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,9 +148,6 @@ jobs:
       name: Install Python
       with:
         python-version: '3.10'
-    - name: Install cibuildwheel
-      run: |
-        python -m pip install cibuildwheel==2.10.2
     - name: Run MacOS Preinstall Build
       if: startsWith(matrix.os, 'macos')
       run: |
@@ -166,25 +163,15 @@ jobs:
         choco install vcpython27 -f -y
         ci\install_libspatialindex.bat
     - name: Build wheels
-      run: |
-        python3 -m cibuildwheel --output-dir wheelhouse
+      uses: pypa/cibuildwheel@v2.11.2
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }}-whl
         path: wheelhouse/*.whl
 
   wheels_aarch64:
-    name: Build wheel on aarch64 for ${{ matrix.python_tag }}
+    name: Build Linux wheels on aarch64
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-       python_tag: [ "cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
-    env:
-      CIBW_ARCHS_LINUX: aarch64
-      CIBW_BUILD: ${{matrix.python_tag}}
-      CIBW_TEST_REQUIRES: pytest numpy
-      CIBW_TEST_COMMAND: "pytest -v {project}/tests"
-      CIBW_BEFORE_BUILD_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
 
     steps:
     - uses: actions/checkout@v3
@@ -192,14 +179,17 @@ jobs:
       name: Install Python
       with:
         python-version: '3.10'
-    - name: Install cibuildwheel
-      run: |
-        python -m pip install cibuildwheel==2.10.2
     - uses: docker/setup-qemu-action@v2
       name: Set up QEMU
+      with:
+        platforms: arm64
     - name: Build wheels
-      run: |
-        python -m cibuildwheel --output-dir wheelhouse
+      uses: pypa/cibuildwheel@v2.11.2
+      env:
+        CIBW_ARCHS_LINUX: aarch64
+        CIBW_TEST_REQUIRES: pytest numpy
+        CIBW_TEST_COMMAND: "pytest -v {project}/tests"
+        CIBW_BEFORE_BUILD_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
     - uses: actions/upload-artifact@v3
       with:
         name: aarch64-whl
@@ -209,7 +199,7 @@ jobs:
     name: Package and push release
 
     #needs: [windows-wheel, linux-wheel, osx-wheel, conda, ubuntu]
-    needs: [conda, ubuntu, wheels]
+    needs: [conda, ubuntu, wheels, wheels_aarch64]
 
     runs-on: 'ubuntu-latest'
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
       MACOSX_DEPLOYMENT_TARGET: 10.9
       CIBW_BUILD_VERBOSITY_MACOS: 3
-      CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+      CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-musllinux*"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
       CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
@@ -189,6 +189,7 @@ jobs:
         CIBW_ARCHS_LINUX: aarch64
         CIBW_TEST_REQUIRES: pytest numpy
         CIBW_TEST_COMMAND: "pytest -v {project}/tests"
+        CIBW_TEST_SKIP: "cp37-* *-musllinux*"
         CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
       CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
-      CIBW_BEFORE_BUILD_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
+      CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
@@ -189,7 +189,7 @@ jobs:
         CIBW_ARCHS_LINUX: aarch64
         CIBW_TEST_REQUIRES: pytest numpy
         CIBW_TEST_COMMAND: "pytest -v {project}/tests"
-        CIBW_BEFORE_BUILD_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
+        CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
     - uses: actions/upload-artifact@v3
       with:
         name: aarch64-whl


### PR DESCRIPTION
Refactor and simplify the wheel building. A single job now builds all `aarch64` wheels, using the [cibuildwheel](https://github.com/pypa/cibuildwheel) GitHub Action (following [these docs](https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation)).

The regular wheels are also build by the GitHub Action.

Another advantage is that Dependabot will update the GitHub Action once a new cibuildwheel version is released.