### PR TITLE
CI: Only run on pushes to the master branch or CI change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on:
   push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/build.yml'
   pull_request:
   release:
     types:


### PR DESCRIPTION
Only run the CI on pushes to the master branch when the CI configuration is changed. This saves some time, since our CI matrix is huge.

Still also runs on all PRs, releases and once a week.