### PR TITLE
Docs: update intersphinx_mapping to modern style

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,7 +219,7 @@ pdf_language = "en_US"
 pdf_fit_mode = "overflow"
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"http://docs.python.org/": None}
+intersphinx_mapping = {"python": ("http://docs.python.org/3", None)}
 
 
 # -- Extension configuration -------------------------------------------------


### PR DESCRIPTION
Today's Sphinx 6.2.0 release deprecated the old style of `intersphinx_mapping`: https://github.com/sphinx-doc/sphinx/pull/11247

This was causing our tests to fail.