### PR TITLE
Fix memory leak when breaking mid-way in _get_objects and _get_ids

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -925,7 +925,6 @@ class Index:
         finally:
             core.rt.Index_DestroyObjResults(its, num_results)
 
-
     def _get_ids(self, it, num_results):
         # take the pointer, yield the results  and free
         items = ctypes.cast(it, ctypes.POINTER(ctypes.c_int64 * num_results))

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -922,10 +922,9 @@ class Index:
                     else:
                         yield self.loads(data)
 
+        finally:
             core.rt.Index_DestroyObjResults(its, num_results)
-        except Exception:  # need to catch all exceptions, not just rtree.
-            core.rt.Index_DestroyObjResults(its, num_results)
-            raise
+
 
     def _get_ids(self, it, num_results):
         # take the pointer, yield the results  and free
@@ -935,10 +934,9 @@ class Index:
         try:
             for i in range(num_results):
                 yield items.contents[i]
+
+        finally:
             core.rt.Index_Free(its)
-        except Exception:
-            core.rt.Index_Free(its)
-            raise
 
     def _nearest_obj(self, coordinates, num_results, objects):
         p_mins, p_maxs = self.get_coordinate_pointers(coordinates)


### PR DESCRIPTION
This PR fixes a memory leak that is caused from resources not being freed when using `_get_objects` and `_get_ids` and not consuming all of the items in the generator.

Explanation - this is the way these functions are implemented currently:
```
>>> def objects():
...   try:
...     for i in range(10):
...       yield i
...     print('release mem 1')
...   except Exception as e:
...     print('release mem 2')
...     raise
```

When iterating the objects, but breaking mid way, the memory is not released:
```
>>> for x in objects():
...   print('got', x)
...   if x == 5: break
... 
got 0
got 1
got 2
got 3
got 4
got 5
>>> 
```

If we use `finally` instead, it simplifies the code and ensures that memory is always released:
```
>>> def objects():
...   try:
...     for i in range(10):
...       yield i
...   finally:
...     print('release mem 3')
```

This works when consuming the entire iterator:
```
>>> for x in objects():
...   print('got', x)
... 
got 0
got 1
...
got 8
got 9
release mem 3
>>> 
```

And when breaking in the middle:
```
>>> for x in objects():
...   print('got', x)
...   if x == 5: break
... 
got 0
got 1
got 2
got 3
got 4
got 5
release mem 3
```