### PR TITLE
Wheel is not a required setup dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Once upon a time, the Python Packaging Tutorial suggested to include wheel as a required dependency for all projects. However, wheel is only needed to build wheels, and https://github.com/pypa/packaging.python.org/pull/1050 removed this suggestion. I think we should just remove this.