### PR TITLE
Drop Python 3.7, upgrade typing for 3.8+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         sidx-version: ['1.8.5','1.9.3']
 
     steps:

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -1,4 +1,4 @@
-- python 3.7+
+- python 3.8+
 - setuptools
 - libspatialindex C library 1.8.5+: 
   https://libspatialindex.org/

--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,5 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python>=3.7
+- python>=3.8
 - libspatialindex>=1.8.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 ]
 description = "R-Tree spatial index for Python GIS"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = ["gis", "spatial", "index", "r-tree"]
 license = {text = "MIT"}
 classifiers = [
@@ -22,16 +22,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Database",
-]
-dependencies = [
-    'typing_extensions>=3.7; python_version<"3.8"',
 ]
 dynamic = ["version"]
 
@@ -50,7 +46,7 @@ version = {attr = "rtree.__version__"}
 rtree = ["lib", "py.typed"]
 
 [tool.black]
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311"]
 color = true
 skip_magic_trailing_comma = true
 

--- a/rtree/__init__.py
+++ b/rtree/__init__.py
@@ -4,6 +4,8 @@
 Rtree provides Python bindings to libspatialindex for quick
 hyperrectangular intersection queries.
 """
+from __future__ import annotations
+
 __version__ = "1.0.1"
 
 from .index import Index, Rtree  # noqa

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 
 from . import finder

--- a/rtree/exceptions.py
+++ b/rtree/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class RTreeError(Exception):
     "RTree exception, indicates a RTree-related error."
     pass

--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -4,6 +4,8 @@ finder.py
 
 Locate `libspatialindex` shared library by any means necessary.
 """
+from __future__ import annotations
+
 import ctypes
 import os
 import platform

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -5,14 +5,8 @@ import os
 import os.path
 import pickle
 import pprint
-import sys
 import warnings
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union, overload
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Any, Iterator, Literal, Sequence, overload
 
 from . import core
 from .exceptions import RTreeError
@@ -306,12 +300,12 @@ class Index:
             self.bounds, self.get_size()
         )
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         del state["handle"]
         return state
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         self.handle = IndexHandle(self.properties.handle)
 
@@ -337,7 +331,7 @@ class Index:
 
     def get_coordinate_pointers(
         self, coordinates: Sequence[float]
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         try:
             iter(coordinates)
         except TypeError:
@@ -587,7 +581,7 @@ class Index:
     @overload
     def contains(
         self, coordinates: Any, objects: Literal[False] = False
-    ) -> Optional[Iterator[int]]:
+    ) -> Iterator[int] | None:
         ...
 
     @overload
@@ -595,8 +589,8 @@ class Index:
         ...
 
     def contains(
-        self, coordinates: Any, objects: Union[bool, Literal["raw"]] = False
-    ) -> Optional[Iterator[Union[Item, int, object]]]:
+        self, coordinates: Any, objects: bool | Literal["raw"] = False
+    ) -> Iterator[Item | int | object] | None:
         """Return ids or objects in the index that contains within the given
         coordinates.
 
@@ -746,8 +740,8 @@ class Index:
         ...
 
     def intersection(
-        self, coordinates: Any, objects: Union[bool, Literal["raw"]] = False
-    ) -> Iterator[Union[Item, int, object]]:
+        self, coordinates: Any, objects: bool | Literal["raw"] = False
+    ) -> Iterator[Item | int | object]:
         """Return ids or objects in the index that intersect the given
         coordinates.
 
@@ -977,8 +971,8 @@ class Index:
         self,
         coordinates: Any,
         num_results: int = 1,
-        objects: Union[bool, Literal["raw"]] = False,
-    ) -> Iterator[Union[Item, int, object]]:
+        objects: bool | Literal["raw"] = False,
+    ) -> Iterator[Item | int | object]:
         """Returns the ``k``-nearest objects to the given coordinates.
 
         :param coordinates: This may be an object that satisfies the numpy array
@@ -1171,7 +1165,7 @@ class Index:
         return core.rt.Index_ClearBuffer(self.handle)
 
     @classmethod
-    def deinterleave(self, interleaved: Sequence[object]) -> List[object]:
+    def deinterleave(self, interleaved: Sequence[object]) -> list[object]:
         """
         [xmin, ymin, xmax, ymax] => [xmin, xmax, ymin, ymax]
 
@@ -1190,7 +1184,7 @@ class Index:
         return di
 
     @classmethod
-    def interleave(self, deinterleaved: Sequence[float]) -> List[float]:
+    def interleave(self, deinterleaved: Sequence[float]) -> list[float]:
         """
         [xmin, xmax, ymin, ymax, zmin, zmax]
             => [xmin, ymin, zmin, xmax, ymax, zmax]
@@ -1379,7 +1373,7 @@ class Item:
         return self.id > other.id
 
     @property
-    def bbox(self) -> List[float]:
+    def bbox(self) -> list[float]:
         """Returns the bounding box of the index entry"""
         return Index.interleave(self.bounds)
 
@@ -1493,19 +1487,19 @@ class Property:
         self.handle = handle
         self.initialize_from_dict(kwargs)
 
-    def initialize_from_dict(self, state: Dict[str, Any]) -> None:
+    def initialize_from_dict(self, state: dict[str, Any]) -> None:
         for k, v in state.items():
             if v is not None:
                 setattr(self, k, v)
 
-    def __getstate__(self) -> Dict[Any, Any]:
+    def __getstate__(self) -> dict[Any, Any]:
         return self.as_dict()
 
     def __setstate__(self, state):
         self.handle = PropertyHandle()
         self.initialize_from_dict(state)
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         d = {}
         for k in self.pkeys:
             try:
@@ -2111,7 +2105,7 @@ class RtreeContainer(Rtree):
                 or isinstance(args[0], ICustomStorage)
             ):
                 raise ValueError("%s supports only in-memory indexes" % self.__class__)
-        self._objects: Dict[int, Tuple[int, object]] = {}
+        self._objects: dict[int, tuple[int, object]] = {}
         return super().__init__(*args, **kwargs)
 
     def get_size(self) -> int:
@@ -2188,7 +2182,7 @@ class RtreeContainer(Rtree):
 
     def intersection(
         self, coordinates: Any, bbox: bool = False
-    ) -> Iterator[Union[Item, object]]:
+    ) -> Iterator[Item | object]:
         """Return ids or objects in the index that intersect the given
         coordinates.
 
@@ -2269,7 +2263,7 @@ class RtreeContainer(Rtree):
 
     def nearest(
         self, coordinates: Any, num_results: int = 1, bbox: bool = False
-    ) -> Iterator[Union[Item, object]]:
+    ) -> Iterator[Item | object]:
         """Returns the ``k``-nearest objects to the given coordinates
         in increasing distance order.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 from typing import Iterator

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,5 @@
 import ctypes
 import pickle
-import sys
 import tempfile
 import unittest
 from typing import Dict, Iterator, Tuple
@@ -587,13 +586,11 @@ class IndexSerialization(unittest.TestCase):
             ),
         ]
 
-        if sys.maxsize > 2**32:
-            # TODO: this fails with CPython 3.7 manylinux i686 i.e. 32-bit
-            # go through the traversal and see if everything is close
-            assert all(
-                all(np.allclose(a, b) for a, b in zip(L, E))
-                for L, E in zip(leaves, expected)
-            )
+        # go through the traversal and see if everything is close
+        assert all(
+            all(np.allclose(a, b) for a, b in zip(L, E))
+            for L, E in zip(leaves, expected)
+        )
 
         hits2 = sorted(list(idx.intersection((0, 60, 0, 60), objects=True)))
         self.assertTrue(len(hits2), 10)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import pickle
 import tempfile

--- a/tests/test_tpr.py
+++ b/tests/test_tpr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 from collections import defaultdict, namedtuple


### PR DESCRIPTION
This PR drops Python 3.7 which reached it's end-of-life in June 2023 ([PEP 537](https://peps.python.org/pep-0537/)).

Testing and some code is modified to assume Python 3.8+. Some of this was automated using `pyupgrade --py38-plus`.

Closes #228