### PR TITLE
Refactor cibuildwheel setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,8 @@ jobs:
   wheels:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.9
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,18 +131,6 @@ jobs:
   wheels:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      CIBW_SKIP: "pp* *-win32 cp312-*"  # remove once numpy supports Python 3.12
-      CIBW_TEST_REQUIRES: pytest numpy
-      CIBW_TEST_COMMAND: "pytest -v {project}/tests"
-      # we are copying the shared libraries ourselves so skip magical copy
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-      CIBW_BUILD_VERBOSITY_MACOS: 3
-      CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-musllinux* *i686"
-      CIBW_ARCHS_MACOS: "x86_64 arm64"
-      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
-      CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
@@ -173,39 +161,11 @@ jobs:
         name: ${{ matrix.os }}-whl
         path: wheelhouse/*.whl
 
-  wheels_aarch64:
-    name: Build Linux wheels on aarch64
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      name: Install Python
-      with:
-        python-version: '3.11'
-    - uses: docker/setup-qemu-action@v2
-      name: Set up QEMU
-      with:
-        platforms: arm64
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.15.0
-      env:
-        CIBW_SKIP: pp*
-        CIBW_ARCHS_LINUX: aarch64
-        CIBW_TEST_REQUIRES: pytest numpy
-        CIBW_TEST_COMMAND: "pytest -v {project}/tests"
-        CIBW_TEST_SKIP: "*-musllinux*"
-        CIBW_BEFORE_ALL_LINUX: "pip install cmake; bash {project}/ci/install_libspatialindex.bash"
-    - uses: actions/upload-artifact@v3
-      with:
-        name: aarch64-whl
-        path: wheelhouse/*.whl
-
   collect-artifacts:
     name: Package and push release
 
     #needs: [windows-wheel, linux-wheel, osx-wheel, conda, ubuntu]
-    needs: [conda, ubuntu, wheels, wheels_aarch64]
+    needs: [conda, ubuntu, wheels]
 
     runs-on: 'ubuntu-latest'
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,13 +148,6 @@ jobs:
       name: Install Python
       with:
         python-version: '3.11'
-    - name: Run MacOS Preinstall Build
-      if: startsWith(matrix.os, 'macos')
-      run: |
-        # provides sha256sum
-        brew install coreutils
-        pip install cmake
-        bash ci/install_libspatialindex.bash
     - uses: ilammy/msvc-dev-cmd@v1
       if: startsWith(matrix.os, 'windows')
     - name: Run Windows Preinstall Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,7 @@ jobs:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
+      # sync this with tool.cibuildwheel.macos.environment in pyproject.toml
       MACOSX_DEPLOYMENT_TARGET: 10.9
     strategy:
       matrix:
@@ -142,7 +143,7 @@ jobs:
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2
       with:
-        platforms: all
+        platforms: arm64
     - uses: actions/setup-python@v4
       name: Install Python
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v3
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
     - uses: actions/setup-python@v4
       name: Install Python
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,9 +131,6 @@ jobs:
   wheels:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      # sync this with tool.cibuildwheel.macos.environment in pyproject.toml
-      MACOSX_DEPLOYMENT_TARGET: 10.9
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 include
 lib
 .coverage
+.tox
+wheelhouse

--- a/ci/install_libspatialindex.bash
+++ b/ci/install_libspatialindex.bash
@@ -47,7 +47,7 @@ cp "${SL}/CMakeLists.txt" ..
 printenv
 
 if [ "$(uname)" == "Darwin" ]; then
-    CMAKE_ARGS="-DCMAKE_OSX_ARCHITECTURES=${AUDITWHEEL_ARCH/ /;}"
+    CMAKE_ARGS="-DCMAKE_OSX_ARCHITECTURES=${ARCHFLAGS##* }"
 fi
 
 cmake -DCMAKE_BUILD_TYPE=Release ${CMAKE_ARGS} ..

--- a/ci/install_libspatialindex.bash
+++ b/ci/install_libspatialindex.bash
@@ -37,7 +37,7 @@ curl -L -O https://github.com/libspatialindex/libspatialindex/archive/$VERSION.z
 echo "${SHA256}  ${VERSION}.zip" | sha256sum -c -
 
 rm -rf "libspatialindex-${VERSION}" || true
-unzip $VERSION
+unzip -q $VERSION
 cd libspatialindex-${VERSION}
 
 mkdir build

--- a/ci/install_libspatialindex.bash
+++ b/ci/install_libspatialindex.bash
@@ -5,7 +5,6 @@ set -xe
 VERSION=1.9.3
 SHA256=63a03bfb26aa65cf0159f925f6c3491b6ef79bc0e3db5a631d96772d6541187e
 
-
 # where to copy resulting files
 # this has to be run before `cd`-ing anywhere
 gentarget() {
@@ -45,7 +44,13 @@ cd build
 
 cp "${SL}/CMakeLists.txt" ..
 
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="${CIBW_ARCHS_MACOS/ /;}" ..
+printenv
+
+if [ "$(uname)" == "Darwin" ]; then
+    CMAKE_ARGS="-DCMAKE_OSX_ARCHITECTURES=${AUDITWHEEL_ARCH/ /;}"
+fi
+
+cmake -DCMAKE_BUILD_TYPE=Release ${CMAKE_ARGS} ..
 make -j 4
 
 # copy built libraries relative to path of this script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ before-build = [
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
 test-skip = "*-macosx_arm64"
-environment = { MACOSX_DEPLOYMENT_TARGET="10.9", CIBW_ARCHS_MACOS="x86_64 arm64" }
+environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
 before-build = [
     "brew install coreutils cmake",
     "bash {project}/ci/install_libspatialindex.bash",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,33 @@ target-version = ["py38", "py39", "py310", "py311"]
 color = true
 skip_magic_trailing_comma = true
 
+[tool.cibuildwheel]
+build = "cp39-*"
+build-verbosity = "3"
+repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
+test-requires = "tox"
+test-command = "tox --conf {project} --installpkg {wheel}"
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]
+# test-skip = "*-musllinux* *i686"
+before-all = [
+    "yum install -y cmake libffi-devel",
+    "bash {project}/ci/install_libspatialindex.bash",
+]
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = [
+    "apk add cmake libffi-dev",
+    "bash {project}/ci/install_libspatialindex.bash",
+]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
+environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
+
 [tool.coverage.report]
 # Ignore warnings for overloads
 # https://github.com/nedbat/coveragepy/issues/970#issuecomment-612602180

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,14 @@ test-command = "tox --conf {project} --installpkg {wheel}"
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
 test-skip = "*aarch64"  # slow!
-before-all = [
+before-build = [
     "yum install -y cmake libffi-devel",
     "bash {project}/ci/install_libspatialindex.bash",
 ]
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-all = [
+before-build = [
     "apk add cmake libffi-dev",
     "bash {project}/ci/install_libspatialindex.bash",
 ]
@@ -75,11 +75,9 @@ before-all = [
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
 test-skip = "*-macosx_arm64"
-# sync this with .github/workflows/build.yml
-environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
-before-all = [
-    "brew install coreutils",  # provides sha256sum
-    "pip install cmake",
+environment = { MACOSX_DEPLOYMENT_TARGET="10.9", CIBW_ARCHS_MACOS="x86_64 arm64" }
+before-build = [
+    "brew install coreutils cmake",
     "bash {project}/ci/install_libspatialindex.bash",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ archs = ["x86_64", "arm64"]
 test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
 environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
 
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]
+
 [tool.coverage.report]
 # Ignore warnings for overloads
 # https://github.com/nedbat/coveragepy/issues/970#issuecomment-612602180

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test-command = "tox --conf {project} --installpkg {wheel}"
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
-# test-skip = "*i686 musllinux_*_aarch64"
+test-skip = "*aarch64"  # slow!
 before-all = [
     "yum install -y cmake libffi-devel",
     "bash {project}/ci/install_libspatialindex.bash",
@@ -74,7 +74,7 @@ before-all = [
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
+# test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
 environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ color = true
 skip_magic_trailing_comma = true
 
 [tool.cibuildwheel]
-build = "cp39-*"
+build = "cp38-*"
 build-verbosity = "3"
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"
@@ -59,7 +59,7 @@ test-command = "tox --conf {project} --installpkg {wheel}"
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
-# test-skip = "*-musllinux* *i686"
+# test-skip = "*i686 musllinux_*_aarch64"
 before-all = [
     "yum install -y cmake libffi-devel",
     "bash {project}/ci/install_libspatialindex.bash",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ archs = ["x86_64", "arm64"]
 test-skip = "*-macosx_arm64"
 # sync this with .github/workflows/build.yml
 environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
+before-all = [
+    "brew install coreutils",  # provides sha256sum
+    "pip install cmake",
+    "bash {project}/ci/install_libspatialindex.bash",
+]
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,8 @@ before-all = [
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-# test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
+test-skip = "*-macosx_arm64"
+# sync this with .github/workflows/build.yml
 environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
 
 [tool.cibuildwheel.windows]

--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -79,14 +79,18 @@ def load() -> ctypes.CDLL:
             lib_name = "libspatialindex_c.so"
 
             # add path for binary wheel prepared with cibuildwheel/auditwheel
-            for file in importlib.metadata.files("rtree"):  # type: ignore
-                if (
-                    file.parent.name == "Rtree.libs"
-                    and file.stem.startswith("libspatialindex")
-                    and ".so" in file.suffixes
-                ):
-                    _candidates.insert(1, os.path.join(str(file.locate())))
-                    break
+            try:
+                pkg_files = importlib.metadata.files("rtree")
+                for file in pkg_files:  # type: ignore
+                    if (
+                        file.parent.name == "Rtree.libs"
+                        and file.stem.startswith("libspatialindex")
+                        and ".so" in file.suffixes
+                    ):
+                        _candidates.insert(1, os.path.join(str(file.locate())))
+                        break
+            except importlib.metadata.PackageNotFoundError:
+                pass
 
         # get the starting working directory
         cwd = os.getcwd()

--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -73,8 +73,20 @@ def load() -> ctypes.CDLL:
             # macos shared libraries are `.dylib`
             lib_name = "libspatialindex_c.dylib"
         else:
+            import importlib.metadata
+
             # linux shared libraries are `.so`
             lib_name = "libspatialindex_c.so"
+
+            # add path for binary wheel prepared with cibuildwheel/auditwheel
+            for file in importlib.metadata.files("rtree"):
+                if (
+                    file.parent.name == "Rtree.libs"
+                    and file.stem.startswith("libspatialindex")
+                    and ".so" in file.suffixes
+                ):
+                    _candidates.insert(1, os.path.join(str(file.locate())))
+                    break
 
         # get the starting working directory
         cwd = os.getcwd()

--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -79,7 +79,7 @@ def load() -> ctypes.CDLL:
             lib_name = "libspatialindex_c.so"
 
             # add path for binary wheel prepared with cibuildwheel/auditwheel
-            for file in importlib.metadata.files("rtree"):
+            for file in importlib.metadata.files("rtree"):  # type: ignore
                 if (
                     file.parent.name == "Rtree.libs"
                     and file.stem.startswith("libspatialindex")

--- a/scripts/repair_wheel.py
+++ b/scripts/repair_wheel.py
@@ -64,7 +64,8 @@ def main():
             shutil.copyfile(file, tmpdir / file.name)
         (file,) = tmpdir.glob("*.whl")
 
-        # we need to handle macOS universal2 & arm64 here for now, let's use platform_tag_args for this.
+        # we need to handle macOS universal2 & arm64 here for now,
+        # let's use platform_tag_args for this.
         platform_tag_args = []
         if os_ == "macos":
             additional_platforms = []
@@ -85,7 +86,8 @@ def main():
             additional_platforms.append("macosx_{}_{}_arm64".format(*arm64_target))
 
             if target < (11, 0):
-                # They're were also issues with pip not picking up some universal2 wheels, tag twice
+                # They're were also issues with pip not picking up some
+                # universal2 wheels, tag twice
                 additional_platforms.append("macosx_11_0_universal2")
 
             platform_tag_args = [f"--platform-tag=+{'.'.join(additional_platforms)}"]
@@ -107,7 +109,7 @@ def main():
         )
         (file,) = tmpdir.glob("*.whl")
         # unpack
-        proc = subprocess.run(["wheel", "unpack", file.name], cwd=tmpdir, check=True)
+        subprocess.run(["wheel", "unpack", file.name], cwd=tmpdir, check=True)
         for unpackdir in tmpdir.iterdir():
             if unpackdir.is_dir():
                 break

--- a/scripts/repair_wheel.py
+++ b/scripts/repair_wheel.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main():
+    if sys.platform.startswith("linux"):
+        os_ = "linux"
+    elif sys.platform.startswith("darwin"):
+        os_ = "macos"
+    elif sys.platform.startswith("win32"):
+        os_ = "windows"
+    else:
+        raise NotImplementedError(
+            "sys.platform '{}' is not supported yet.".format(sys.platform)
+        )
+
+    p = argparse.ArgumentParser(
+        description="Convert wheel to be independent of python implementation and ABI"
+    )
+    p.set_defaults(prog=Path(sys.argv[0]).name)
+    p.add_argument("WHEEL_FILE", help="Path to wheel file.")
+    p.add_argument(
+        "-w",
+        "--wheel-dir",
+        dest="WHEEL_DIR",
+        help=('Directory to store delocated wheels (default: "wheelhouse/")'),
+        default="wheelhouse/",
+    )
+
+    args = p.parse_args()
+
+    file = Path(args.WHEEL_FILE).resolve(strict=True)
+    wheelhouse = Path(args.WHEEL_DIR).resolve()
+    wheelhouse.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir_:
+        tmpdir = Path(tmpdir_)
+        # use the platform specific repair tool first
+        if os_ == "linux":
+            subprocess.run(
+                ["auditwheel", "repair", "-w", str(tmpdir), str(file)], check=True
+            )
+        elif os_ == "macos":
+            subprocess.run(
+                [
+                    "delocate-wheel",
+                    "--require-archs",
+                    "arm64,x86_64",
+                    "-w",
+                    str(tmpdir),
+                    str(file),
+                ],
+                check=True,
+            )
+        elif os_ == "windows":
+            # no specific tool, just copy
+            shutil.copyfile(file, tmpdir / file.name)
+        (file,) = tmpdir.glob("*.whl")
+
+        # we need to handle macOS universal2 & arm64 here for now, let's use platform_tag_args for this.
+        platform_tag_args = []
+        if os_ == "macos":
+            additional_platforms = []
+
+            # first, get the target macOS deployment target from the wheel
+            match = re.match(r"^.*-macosx_(\d+)_(\d+)_x86_64\.whl$", file.name)
+            assert match is not None
+            target = tuple(map(int, match.groups()))
+
+            # let's add universal2 platform for this wheel.
+            additional_platforms = ["macosx_{}_{}_universal2".format(*target)]
+
+            # given pip support for universal2 was added after arm64 introduction
+            # let's also add arm64 platform.
+            arm64_target = target
+            if arm64_target < (11, 0):
+                arm64_target = (11, 0)
+            additional_platforms.append("macosx_{}_{}_arm64".format(*arm64_target))
+
+            if target < (11, 0):
+                # They're were also issues with pip not picking up some universal2 wheels, tag twice
+                additional_platforms.append("macosx_11_0_universal2")
+
+            platform_tag_args = [f"--platform-tag=+{'.'.join(additional_platforms)}"]
+
+        # make this a py3 wheel
+        subprocess.run(
+            [
+                "wheel",
+                "tags",
+                "--python-tag",
+                "py3",
+                "--abi-tag",
+                "none",
+                *platform_tag_args,
+                "--remove",
+                str(file),
+            ],
+            check=True,
+        )
+        (file,) = tmpdir.glob("*.whl")
+        # unpack
+        proc = subprocess.run(["wheel", "unpack", file.name], cwd=tmpdir, check=True)
+        for unpackdir in tmpdir.iterdir():
+            if unpackdir.is_dir():
+                break
+        else:
+            raise RuntimeError("subdirectory not found")
+        if os_ == "linux":
+            # remove duplicated dir
+            assert len(list((unpackdir / "Rtree.libs").glob("*.so*"))) >= 1
+            lib_dir = unpackdir / "rtree" / "lib"
+            shutil.rmtree(lib_dir)
+        # re-pack
+        subprocess.run(["wheel", "pack", str(unpackdir.name)], cwd=tmpdir, check=True)
+        files = list(tmpdir.glob("*.whl"))
+        assert len(files) == 1, files
+        file = files[0]
+        file.rename(wheelhouse / file.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repair_wheel.py
+++ b/scripts/repair_wheel.py
@@ -50,8 +50,8 @@ def main():
             subprocess.run(
                 [
                     "delocate-wheel",
-                    "--require-archs",
-                    "arm64,x86_64",
+                    # "--require-archs",
+                    # "arm64,x86_64",
                     "-w",
                     str(tmpdir),
                     str(file),

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+requires =
+    tox>=4
+env_list = type, py{38,39,310,311}
+
+[testenv]
+description = run unit tests
+deps =
+    pytest>=7
+    numpy
+commands =
+    pytest {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,16 @@
 [tox]
 requires =
     tox>=4
-env_list = type, py{38,39,310,311}
+env_list = py{38,39,310,311,312}
 
 [testenv]
 description = run unit tests
 deps =
-    pytest>=7
+    pytest
     numpy
+install_command =
+    python -I -m pip install --only-binary=:all: {opts} {packages}
+ignore_errors = True
+ignore_outcome = True
 commands =
     pytest {posargs:tests}


### PR DESCRIPTION
There are a few aims in this PR:

- Move cibuildwheel data from GitHub Actions variables to pyproject.toml
- Build each platform, but allow to work with any Python 3 version, since this is a Pure Python project
- Use tox to run pytest for all Python versions
- For Linux, remove duplicated `rtree/lib`; close #270
- Modify finder to look for auditwheel-built shared library (using `importlib.metadata.files`)

The repair_wheel.py script was modified from [cmake-python-distributions](https://github.com/scikit-build/cmake-python-distributions/blob/master/scripts/repair_wheel.py). Admittedly, there are several things that I don't understand, but have left alone. It uses `wheel unpack` and `wheel pack` to modify the binary wheels.