### PR TITLE
Support and test Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         sidx-version: ['1.8.5','1.9.3']
 
     steps:
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
@@ -153,7 +153,7 @@ jobs:
         choco install vcpython27 -f -y
         ci\install_libspatialindex.bat
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.16.1
+      uses: pypa/cibuildwheel@v2.16.2
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}-whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Database",
 ]
@@ -46,7 +47,7 @@ version = {attr = "rtree.__version__"}
 rtree = ["lib", "py.typed"]
 
 [tool.black]
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 color = true
 skip_magic_trailing_comma = true
 


### PR DESCRIPTION
Python 3.12 is out, so add "support" and test the version. Upgrade to cibuildwheel from today is for the Python 3.12.0 final release.

I'll suggest a micro release soon, so Python 3.12 folks can use the new built wheels.