### PR TITLE
Skip test failing on i386.

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import pickle
+import sys
 import tempfile
 import unittest
 from typing import Iterator
@@ -451,6 +452,7 @@ class IndexSerialization(unittest.TestCase):
         self.assertTrue(len(hits), 10)
         self.assertEqual(hits, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
 
+    @pytest.mark.skipif(not sys.maxsize > 2**32, reason="Fails on 32bit systems")
     def test_interleaving(self) -> None:
         """Streaming against a persisted index without interleaving"""
 


### PR DESCRIPTION
The Debian package build for rtree failed on i386 due to test failures:
```
I: pybuild base:291: cd /builds/debian-gis-team/python-rtree/debian/output/source_dir/.pybuild/cpython3_3.11_rtree/build; python3.11 -m pytest tests
============================= test session starts ==============================
platform linux -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
rootdir: /builds/debian-gis-team/python-rtree/debian/output/source_dir
collected 38 items
tests/test_index.py ........x............F...............                [ 97%]
tests/test_tpr.py .                                                      [100%]
=================================== FAILURES ===================================
_____________________ IndexSerialization.test_interleaving _____________________
self = <tests.test_index.IndexSerialization testMethod=test_interleaving>
    def test_interleaving(self) -> None:
        """Streaming against a persisted index without interleaving"""
    
        def data_gen(
            interleaved: bool = True,
        ) -> Iterator[tuple[int, tuple[float, float, float, float], int]]:
            for i, (minx, miny, maxx, maxy) in enumerate(self.boxes15):
                if interleaved:
                    yield (i, (minx, miny, maxx, maxy), 42)
                else:
                    yield (i, (minx, maxx, miny, maxy), 42)
    
        p = index.Property()
        tname = tempfile.mktemp()
        idx = index.Index(
            tname, data_gen(interleaved=False), properties=p, interleaved=False
        )
        hits1 = sorted(list(idx.intersection((0, 60, 0, 60))))
        self.assertTrue(len(hits1), 10)
        self.assertEqual(hits1, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
    
        leaves = idx.leaves()
        expected = [
            (
                0,
                [
                    2,
                    92,
                    51,
                    55,
                    26,
                    95,
                    7,
                    81,
                    38,
                    22,
                    58,
                    89,
                    91,
                    83,
                    98,
                    37,
                    70,
                    31,
                    49,
                    34,
                    11,
                    6,
                    13,
                    3,
                    23,
                    57,
                    9,
                    96,
                    84,
                    36,
                    5,
                    45,
                    77,
                    78,
                    44,
                    12,
                    42,
                    73,
                    93,
                    41,
                    71,
                    17,
                    39,
                    54,
                    88,
                    72,
                    97,
                    60,
                    62,
                    48,
                    19,
                    25,
                    76,
                    59,
                    66,
                    64,
                    79,
                    94,
                    40,
                    32,
                    46,
                    47,
                    15,
                    68,
                    10,
                    0,
                    80,
                    56,
                    50,
                    30,
                ],
                [-186.673789279, -96.7177218184, 172.392784956, 45.4856075292],
            ),
            (
                2,
                [
                    61,
                    74,
                    29,
                    99,
                    16,
                    43,
                    35,
                    33,
                    27,
                    63,
                    18,
                    90,
                    8,
                    53,
                    82,
                    21,
                    65,
                    24,
                    4,
                    1,
                    75,
                    67,
                    86,
                    52,
                    28,
                    85,
                    87,
                    14,
                    69,
                    20,
                ],
                [-174.739939684, 32.6596016791, 184.761387556, 96.6043699778],
            ),
        ]
    
        # go through the traversal and see if everything is close
>       assert all(
            all(np.allclose(a, b) for a, b in zip(L, E))  # type: ignore
            for L, E in zip(leaves, expected)
        )
/builds/debian-gis-team/python-rtree/debian/output/source_dir/.pybuild/cpython3_3.11_rtree/build/tests/test_index.py:592: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/builds/debian-gis-team/python-rtree/debian/output/source_dir/.pybuild/cpython3_3.11_rtree/build/tests/test_index.py:592: in <genexpr>
    assert all(
/builds/debian-gis-team/python-rtree/debian/output/source_dir/.pybuild/cpython3_3.11_rtree/build/tests/test_index.py:592: in <genexpr>
    assert all(
<__array_function__ internals>:200: in allclose
    ???
/usr/lib/python3/dist-packages/numpy/core/numeric.py:2270: in allclose
    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
<__array_function__ internals>:200: in isclose
    ???
/usr/lib/python3/dist-packages/numpy/core/numeric.py:2380: in isclose
    return within_tol(x, y, atol, rtol)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
x = array([ 2, 92, 51, 55, 26, 95,  7, 81, 38, 22, 58, 89, 91, 83, 98, 37, 70,
       31, 49, 34, 11,  6, 13,  3, 23, 57, ... 54, 88, 72, 97, 60, 62, 48, 19,
       25, 76, 59, 66, 64, 79, 94, 40, 32, 46, 47, 15, 68, 10,  0, 80, 56,
       50])
y = array([ 2., 92., 51., 55., 26., 95.,  7., 81., 38., 22., 58., 89., 91.,
       83., 98., 37., 70., 31., 49., 34., 11.,...48., 19., 25.,
       76., 59., 66., 64., 79., 94., 40., 32., 46., 47., 15., 68., 10.,
        0., 80., 56., 50., 30.])
atol = 1e-08, rtol = 1e-05
    def within_tol(x, y, atol, rtol):
        with errstate(invalid='ignore'), _no_nep50_warning():
>           return less_equal(abs(x-y), atol + rtol * abs(y))
E           ValueError: operands could not be broadcast together with shapes (69,) (70,)
/usr/lib/python3/dist-packages/numpy/core/numeric.py:2361: ValueError
=========================== short test summary info ============================
FAILED tests/test_index.py::IndexSerialization::test_interleaving - ValueError: operands could not be broadcast together with shapes (69,) (70,)
=================== 1 failed, 36 passed, 1 xfailed in 0.50s ====================
E: pybuild pybuild:395: test: plugin pyproject failed with: exit code=1: cd /builds/debian-gis-team/python-rtree/debian/output/source_dir/.pybuild/cpython3_3.11_rtree/build; python3.11 -m pytest tests
```

Skipping the test on 32bit architectures resolves the issue.