### PR TITLE
Fix test failure with built library.

### DIFF
--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -81,14 +81,15 @@ def load() -> ctypes.CDLL:
             # add path for binary wheel prepared with cibuildwheel/auditwheel
             try:
                 pkg_files = importlib.metadata.files("rtree")
-                for file in pkg_files:  # type: ignore
-                    if (
-                        file.parent.name == "Rtree.libs"
-                        and file.stem.startswith("libspatialindex")
-                        and ".so" in file.suffixes
-                    ):
-                        _candidates.insert(1, os.path.join(str(file.locate())))
-                        break
+                if pkg_files is not None:
+                    for file in pkg_files:  # type: ignore
+                        if (
+                            file.parent.name == "Rtree.libs"
+                            and file.stem.startswith("libspatialindex")
+                            and ".so" in file.suffixes
+                        ):
+                            _candidates.insert(1, os.path.join(str(file.locate())))
+                            break
             except importlib.metadata.PackageNotFoundError:
                 pass
 


### PR DESCRIPTION
The autopkgtest for the Debian package fails:
```
I: pybuild base:291: cd /tmp/autopkgtest-lxc.o4fl70zh/downtmp/autopkgtest_tmp/build; python3.11 -m pytest tests
============================= test session starts ==============================
platform linux -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
rootdir: /tmp/autopkgtest-lxc.o4fl70zh/downtmp/autopkgtest_tmp/build
collected 0 items / 2 errors
==================================== ERRORS ====================================
_____________________ ERROR collecting tests/test_index.py _____________________
/usr/lib/python3/dist-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
/usr/lib/python3/dist-packages/_pytest/runner.py:372: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
/usr/lib/python3/dist-packages/_pytest/python.py:531: in collect
    self._inject_setup_module_fixture()
/usr/lib/python3/dist-packages/_pytest/python.py:545: in _inject_setup_module_fixture
    self.obj, ("setUpModule", "setup_module")
/usr/lib/python3/dist-packages/_pytest/python.py:310: in obj
    self._obj = obj = self._getobj()
/usr/lib/python3/dist-packages/_pytest/python.py:528: in _getobj
    return self._importtestmodule()
/usr/lib/python3/dist-packages/_pytest/python.py:617: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
/usr/lib/python3/dist-packages/_pytest/pathlib.py:567: in import_path
    importlib.import_module(module_name)
/usr/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:690: in _load_unlocked
    ???
/usr/lib/python3/dist-packages/_pytest/assertion/rewrite.py:178: in exec_module
    exec(co, module.__dict__)
tests/test_index.py:13: in <module>
    import rtree
/usr/lib/python3/dist-packages/rtree/__init__.py:11: in <module>
    from .index import Index, Rtree  # noqa
/usr/lib/python3/dist-packages/rtree/index.py:11: in <module>
    from . import core
/usr/lib/python3/dist-packages/rtree/core.py:76: in <module>
    rt = finder.load()
/usr/lib/python3/dist-packages/rtree/finder.py:84: in load
    for file in pkg_files:  # type: ignore
E   TypeError: 'NoneType' object is not iterable
______________________ ERROR collecting tests/test_tpr.py ______________________
/usr/lib/python3/dist-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
/usr/lib/python3/dist-packages/_pytest/runner.py:372: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
/usr/lib/python3/dist-packages/_pytest/python.py:531: in collect
    self._inject_setup_module_fixture()
/usr/lib/python3/dist-packages/_pytest/python.py:545: in _inject_setup_module_fixture
    self.obj, ("setUpModule", "setup_module")
/usr/lib/python3/dist-packages/_pytest/python.py:310: in obj
    self._obj = obj = self._getobj()
/usr/lib/python3/dist-packages/_pytest/python.py:528: in _getobj
    return self._importtestmodule()
/usr/lib/python3/dist-packages/_pytest/python.py:617: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
/usr/lib/python3/dist-packages/_pytest/pathlib.py:567: in import_path
    importlib.import_module(module_name)
/usr/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:690: in _load_unlocked
    ???
/usr/lib/python3/dist-packages/_pytest/assertion/rewrite.py:178: in exec_module
    exec(co, module.__dict__)
tests/test_tpr.py:11: in <module>
    from rtree.index import Index, Property, RT_TPRTree
/usr/lib/python3/dist-packages/rtree/__init__.py:11: in <module>
    from .index import Index, Rtree  # noqa
/usr/lib/python3/dist-packages/rtree/index.py:11: in <module>
    from . import core
/usr/lib/python3/dist-packages/rtree/core.py:76: in <module>
    rt = finder.load()
/usr/lib/python3/dist-packages/rtree/finder.py:84: in load
    for file in pkg_files:  # type: ignore
E   TypeError: 'NoneType' object is not iterable
=========================== short test summary info ============================
ERROR tests/test_index.py - TypeError: 'NoneType' object is not iterable
ERROR tests/test_tpr.py - TypeError: 'NoneType' object is not iterable
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 2 errors in 0.49s ===============================
E: pybuild pybuild:395: test: plugin pyproject failed with: exit code=2: cd /tmp/autopkgtest-lxc.o4fl70zh/downtmp/autopkgtest_tmp/build; python3.11 -m pytest tests
```

Only iterating `pkg_files` when it's not `None` resolves the issue.