### PR TITLE
Docs updates - multithreading/process recommendations + strikethrough of disk serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ user.  These features include:
 * Clustered indexes (store Python pickles directly with index entries)
 * Bulk loading
 * Deletion
-* Disk serialization
+* ~~Disk serialization~~ [currently broken as of Jan 2024](https://github.com/Toblerity/rtree/pull/197)
 * Custom storage implementation (to implement spatial indexing in ZODB, for example)
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ user.  These features include:
 * ~~Disk serialization~~ [currently broken as of Jan 2024](https://github.com/Toblerity/rtree/pull/197)
 * Custom storage implementation (to implement spatial indexing in ZODB, for example)
 
+These features do not include:
+
+* Multithread safety (for reading or writing)
+* Multiprocess safety (for reading or writing)
+
+For either of these, we recommend using:
+
+* A PostGIS database, or
+* GeoPandas + spatial joining, or
+* Building an rtree from scratch in each thread/process (using [generator syntax](https://rtree.readthedocs.io/en/latest/performance.html#use-stream-loading))
+
+Note that since rtree is written in C, it can be orders of magnitude faster than a 
+database even if running sequentially.
 
 Wheels are available for most major platforms, and `rtree` with bundled `libspatialindex` can be installed via pip:
 


### PR DESCRIPTION
Given the multithreading/processing issues with rtree and libspatialindex, I thought it made sense to add this info to the README (and also the online docs). 

Related discussions that inspired my updates:

* https://github.com/libspatialindex/libspatialindex/issues/71
* #53 
* #105