### PR TITLE
Drop Python 3.8 support, require Python 3.9+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         # test oldesst and newest libspatialindex versions
         sidx-version: ['1.8.5', '2.0.0']
         exclude:
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -1,4 +1,4 @@
-- python 3.8+
+- python 3.9+
 - setuptools
 - libspatialindex C library 1.8.5+:
   https://libspatialindex.org/

--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,5 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python>=3.8
+- python>=3.9
 - libspatialindex>=1.8.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 ]
 description = "R-Tree spatial index for Python GIS"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["gis", "spatial", "index", "r-tree"]
 license = {text = "MIT"}
 classifiers = [
@@ -23,7 +23,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -49,7 +48,7 @@ version = {attr = "rtree.__version__"}
 rtree = ["py.typed"]
 
 [tool.cibuildwheel]
-build = "cp38-*"
+build = "cp39-*"
 build-verbosity = 3
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -6,7 +6,8 @@ import os.path
 import pickle
 import pprint
 import warnings
-from typing import Any, Iterator, Literal, Sequence, overload
+from collections.abc import Iterator, Sequence
+from typing import Any, Literal, overload
 
 from . import core
 from .exceptions import RTreeError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
-from typing import Iterator
+from collections.abc import Iterator
 
 import py
 import pytest

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -5,7 +5,7 @@ import pickle
 import sys
 import tempfile
 import unittest
-from typing import Iterator
+from collections.abc import Iterator
 
 import numpy as np
 import pytest

--- a/tests/test_tpr.py
+++ b/tests/test_tpr.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import os
 import unittest
 from collections import defaultdict, namedtuple
+from collections.abc import Iterator
 from math import ceil
-from typing import Any, Iterator
+from typing import Any
 
 import numpy as np
 from numpy.random import default_rng

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{38,39,310,311,312}
+env_list = py{39,310,311,312}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
With 1.3.0 freshly released this seems like a good moment to drop Python 3.8 support. It's almost [end-of-life](https://endoflife.date/python) and [SPEC 0](https://scientific-python.org/specs/spec-0000/) already recommended dropping Python 3.8 over a year ago.

In fact, they even recommend already dropping Python 3.9 and requiring 3.10+, which many packages do. But that might be a bit much for one PR.

So this PR bumps the required Python version to 3.9, removes 3.8 from the CI and test files and applies [pyupgrade](https://github.com/asottile/pyupgrade) with `--py39-plus`.

Of course this will only affect future releases, existing releases stay compatible with Python 3.8 and can continued to be used.