### PR TITLE
CI: Add test job for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # test oldesst and newest libspatialindex versions
         sidx-version: ['1.8.5', '2.0.0']
         exclude:
@@ -63,14 +63,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Setup
       run: |
           sudo apt install libspatialindex-c6 python3-pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         # test oldesst and newest libspatialindex versions
         sidx-version: ['1.8.5', '2.0.0']
         exclude:


### PR DESCRIPTION
Python 3.13 is now in beta, thus is might be useful to start testing what works and what doesn't.

This PR adds a Python 3.13 jobs for the conda and regular Ubuntu pip jobs.

It also fixes a bug in the Ubuntu job, by making sure the Python version specified in the matrix is actually used when setting up Python.