### PR TITLE
CI: fail with warnings, and several minor tunings to test workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+        name: cibw-wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,21 +4,12 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/test.yml'
   pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
-
   conda:
     name: Conda ${{ matrix.python-version }} - ${{ matrix.os }}
     defaults:
@@ -26,11 +17,11 @@ jobs:
         shell: bash -l {0}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        # test oldesst and newest libspatialindex versions
+        # test oldest and newest libspatialindex versions
         sidx-version: ['1.8.5', '2.0.0']
         exclude:
           - os: 'macos-latest'
@@ -43,16 +34,15 @@ jobs:
         channels: conda-forge
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
+
     - name: Setup
-      run: |
-          conda install -c conda-forge numpy libspatialindex=${{ matrix.sidx-version }} -y
+      run: conda install -c conda-forge numpy pytest libspatialindex=${{ matrix.sidx-version }} -y
+
     - name: Install
-      run: |
-        pip install -e .
+      run: pip install -e .
+
     - name: Test with pytest
-      run: |
-        pip install pytest
-        python -m pytest --doctest-modules rtree tests
+      run: pytest --import-mode=importlib -Werror -v --doctest-modules rtree tests
 
   ubuntu:
     name: Ubuntu Python ${{ matrix.python-version }}
@@ -61,7 +51,7 @@ jobs:
         shell: bash -l {0}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
@@ -72,15 +62,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
+
     - name: Setup
       run: |
-          sudo apt install libspatialindex-c6 python3-pip
-          python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools numpy pytest
+          sudo apt-get -y install libspatialindex-c6
+          pip install --upgrade pip
+          pip install numpy pytest
 
     - name: Build
-      run: |
-        python3 -m pip install --user .
+      run: pip install --user .
+
     - name: Test with pytest
-      run: |
-        python3 -m pytest --doctest-modules rtree tests
+      run: pytest --import-mode=importlib -Werror -v --doctest-modules rtree tests


### PR DESCRIPTION
Notes on the changes:

- Tests will fail from warnings (`-Werror`)
- Use verbose messages with pytest, since this is the primary output to review
- Change `fail-fast: false` to run all jobs of a matrix, even if there is one failure
- Remove the pre-commit workflow job, since pre-commit.ci was recently configured
- Use conda to install pytest for the conda jobs (not pip)
- Apt should't install python3-pip, and use `apt-get` for non-interactive use
- Remove 'paths' for 'push', so that the tests are re-run after pull-requests are merged to master