### PR TITLE
CI: Always run on push to master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/test.yml'
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Currently the CI doesn't run when a commit is pushed to the master branch, except if the configuration itself is changed. This is a bit strange, because you would always want to validate that the master branch is testing properly, especially with more complex squash / rebase merges.