### PR TITLE
Update .readthedocs.yaml: Use latest Ubuntu and Python versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,9 @@ version: 2
 build:
    apt_packages:
       - libspatialindex-dev
-   os: ubuntu-20.04
+   os: ubuntu-lts-latest
    tools:
-      python: "3.11"
+      python: latest
 
 # Build documentation in the docs/source directory with Sphinx
 sphinx:


### PR DESCRIPTION
Use latest Ubuntu and Python versions for Readthedocs. These are faster and throw more detailed errors if anything goes wrong.