### PR TITLE
MAINT: add Python 3.13 classifier and tox env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Database",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{39,310,311,312}
+env_list = py{39,310,311,312,313}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
CI testing is already done with Python 3.13, but the classifier and tox environment needed to be updated.