### PR TITLE
Consistency checks

### DIFF
--- a/rtree/core.py
+++ b/rtree/core.py
@@ -238,6 +238,44 @@ rt.Index_NearestNeighbors_id.argtypes = [
 rt.Index_NearestNeighbors_id.restype = ctypes.c_int
 rt.Index_NearestNeighbors_id.errcheck = check_return  # type: ignore
 
+try:
+    rt.Index_NearestNeighbors_id_v.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int64,
+        ctypes.c_int64,
+        ctypes.c_uint32,
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int64),
+    ]
+    rt.Index_NearestNeighbors_id_v.restype = ctypes.c_int
+    rt.Index_NearestNeighbors_id_v.errcheck = check_return  # type: ignore
+
+    rt.Index_Intersects_id_v.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int64,
+        ctypes.c_uint32,
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int64),
+    ]
+    rt.Index_Intersects_id_v.restype = ctypes.c_int
+    rt.Index_Intersects_id_v.errcheck = check_return  # type: ignore
+except AttributeError:
+    pass
+
+
 rt.Index_GetLeaves.argtypes = [
     ctypes.c_void_p,
     ctypes.POINTER(ctypes.c_uint32),

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -135,7 +135,7 @@ try:
         ctypes.c_uint64,
         ctypes.c_void_p,
         ctypes.c_void_p,
-        ctypes.c_void_p
+        ctypes.c_void_p,
     ]
     rt.Index_CreateWithArray.restype = ctypes.c_void_p
     rt.Index_CreateWithArray.errcheck = check_void  # type: ignore

--- a/rtree/core.py
+++ b/rtree/core.py
@@ -125,6 +125,23 @@ rt.Index_CreateWithStream.argtypes = [ctypes.c_void_p, NEXTFUNC]
 rt.Index_CreateWithStream.restype = ctypes.c_void_p
 rt.Index_CreateWithStream.errcheck = check_void  # type: ignore
 
+try:
+    rt.Index_CreateWithArray.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint64,
+        ctypes.c_uint32,
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p
+    ]
+    rt.Index_CreateWithArray.restype = ctypes.c_void_p
+    rt.Index_CreateWithArray.errcheck = check_void  # type: ignore
+except AttributeError:
+    pass
+
 rt.Index_Destroy.argtypes = [ctypes.c_void_p]
 rt.Index_Destroy.restype = None
 rt.Index_Destroy.errcheck = check_void_done  # type: ignore

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -360,7 +360,7 @@ class Index:
             if not p <= q:
                 raise RTreeError(
                     "Coordinates must not have minimums more than maximums"
-            )
+                )
 
         return mins, maxs
 

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -1046,6 +1046,107 @@ class Index:
 
         return self._get_ids(it, p_num_results.contents.value)
 
+    def intersection_v(self, mins, maxs):
+        import numpy as np
+
+        assert mins.shape == maxs.shape
+        assert mins.strides == maxs.strides
+
+        # Cast
+        mins = mins.astype(np.float64)
+        maxs = maxs.astype(np.float64)
+
+        # Extract counts
+        n, d = mins.shape
+
+        # Compute strides
+        d_i_stri = mins.strides[0] // mins.itemsize
+        d_j_stri = mins.strides[1] // mins.itemsize
+
+        ids = np.empty(2*n, dtype=np.int64)
+        counts = np.empty(n, dtype=np.uint64)
+        nr = ctypes.c_int64(0)
+        offn, offi = 0, 0
+
+        while True:
+            core.rt.Index_Intersects_id_v(
+                self.handle,
+                n - offn,
+                d,
+                len(ids),
+                d_i_stri,
+                d_j_stri,
+                mins[offn:].ctypes.data,
+                maxs[offn:].ctypes.data,
+                ids[offi:].ctypes.data,
+                counts[offn:].ctypes.data,
+                ctypes.byref(nr)
+            )
+
+            # If we got the expected nuber of results then return
+            if nr.value == n - offn:
+                return ids[:counts.sum()], counts
+            # Otherwise, if our array is too small then resize
+            else:
+                offi += counts[offn:offn + nr.value].sum()
+                offn += nr.value
+
+                ids = ids.resize(2*len(ids), refcheck=False)
+
+    def nearest_v(self, mins, maxs, num_results=1, strict=False,
+                  return_max_dists=False):
+        import numpy as np
+
+        assert mins.shape == maxs.shape
+        assert mins.strides == maxs.strides
+
+        # Cast
+        mins = mins.astype(np.float64)
+        maxs = maxs.astype(np.float64)
+
+        # Extract counts
+        n, d = mins.shape
+
+        # Compute strides
+        d_i_stri = mins.strides[0] // mins.itemsize
+        d_j_stri = mins.strides[1] // mins.itemsize
+
+        ids = np.empty(n*num_results, dtype=np.int64)
+        counts = np.empty(n, dtype=np.uint64)
+        dists = np.empty(n) if return_max_dists else None
+        nr = ctypes.c_int64(0)
+        offn, offi = 0, 0
+
+        while True:
+            core.rt.Index_NearestNeighbors_id_v(
+                self.handle,
+                num_results if not strict else -num_results,
+                n - offn,
+                d,
+                len(ids),
+                d_i_stri,
+                d_j_stri,
+                mins[offn:].ctypes.data,
+                maxs[offn:].ctypes.data,
+                ids[offi:].ctypes.data,
+                counts[offn:].ctypes.data,
+                dists[offn:].ctypes.data if return_max_dists else None,
+                ctypes.byref(nr)
+            )
+
+            # If we got the expected nuber of results then return
+            if nr.value == n - offn:
+                if return_max_dists:
+                    return ids[:counts.sum()], counts, dists
+                else:
+                    return ids[:counts.sum()], counts
+            # Otherwise, if our array is too small then resize
+            else:
+                offi += counts[offn:offn + nr.value].sum()
+                offn += nr.value
+
+                ids = ids.resize(2*len(ids), refcheck=False)
+
     def _nearestTP(self, coordinates, velocities, times, num_results=1, objects=False):
         p_mins, p_maxs = self.get_coordinate_pointers(coordinates)
         pv_mins, pv_maxs = self.get_coordinate_pointers(velocities)

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -1507,7 +1507,8 @@ class Property:
         try:
             return self._type
         except AttributeError:
-            self._type = type = core.rt.IndexProperty_GetIndexType(self.handle)
+            type = core.rt.IndexProperty_GetIndexType(self.handle)
+            self._type: int = type
             return type
 
     def set_index_type(self, value: int) -> None:
@@ -1534,7 +1535,7 @@ class Property:
             return self._dimension
         except AttributeError:
             dim = core.rt.IndexProperty_GetDimension(self.handle)
-            self._dimension = dim
+            self._dimension: int = dim
             return dim
 
     def set_dimension(self, value: int) -> None:

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -1640,7 +1640,7 @@ class Property:
                 setattr(self, k, v)
 
         # Consistency checks
-        if 'near_minimum_overlap_factor' not in state:
+        if "near_minimum_overlap_factor" not in state:
             nmof = self.near_minimum_overlap_factor
             ilc = min(self.index_capacity, self.leaf_capacity)
             if nmof >= ilc:

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -1482,10 +1482,11 @@ class IndexStreamHandle(IndexHandle):
 
 
 try:
+
     class IndexArrayHandle(IndexHandle):
         _create = core.rt.Index_CreateWithArray
 except AttributeError:
-        pass
+    pass
 
 
 class PropertyHandle(Handle):

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -1538,6 +1538,13 @@ class Property:
             if v is not None:
                 setattr(self, k, v)
 
+        # Consistency checks
+        if 'near_minimum_overlap_factor' not in state:
+            nmof = self.near_minimum_overlap_factor
+            ilc = min(self.index_capacity, self.leaf_capacity)
+            if nmof >= ilc:
+                self.near_minimum_overlap_factor = ilc // 3 + 1
+
     def __getstate__(self) -> dict[Any, Any]:
         return self.as_dict()
 

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -331,42 +331,38 @@ class Index:
     def get_coordinate_pointers(
         self, coordinates: Sequence[float]
     ) -> tuple[float, float]:
-        try:
-            iter(coordinates)
-        except TypeError:
-            raise TypeError("Bounds must be a sequence")
         dimension = self.properties.dimension
+        coordinates = list(coordinates)
 
-        mins = ctypes.c_double * dimension
-        maxs = ctypes.c_double * dimension
+        arr = ctypes.c_double * dimension
+        mins = arr()
 
-        if not self.interleaved:
-            coordinates = Index.interleave(coordinates)
-
-        # it's a point make it into a bbox. [x, y] => [x, y, x, y]
+        # Point
         if len(coordinates) == dimension:
-            coordinates = *coordinates, *coordinates
+            mins[:] = coordinates
+            maxs = mins
+        # Bounding box
+        else:
+            maxs = arr()
 
-        if len(coordinates) != dimension * 2:
-            raise RTreeError(
-                "Coordinates must be in the form "
-                "(minx, miny, maxx, maxy) or (x, y) for 2D indexes"
-            )
+            # Interleaved box
+            if self.interleaved:
+                p = coordinates[:dimension]
+                q = coordinates[dimension:]
+            # Non-interleaved box
+            else:
+                p = coordinates[::2]
+                q = coordinates[1::2]
 
-        # so here all coords are in the form:
-        # [xmin, ymin, zmin, xmax, ymax, zmax]
-        for i in range(dimension):
-            if not coordinates[i] <= coordinates[i + dimension]:
+            mins[:] = p
+            maxs[:] = q
+
+            if not p <= q:
                 raise RTreeError(
                     "Coordinates must not have minimums more than maximums"
-                )
+            )
 
-        p_mins = mins(*[ctypes.c_double(coordinates[i]) for i in range(dimension)])
-        p_maxs = maxs(
-            *[ctypes.c_double(coordinates[i + dimension]) for i in range(dimension)]
-        )
-
-        return (p_mins, p_maxs)
+        return mins, maxs
 
     @staticmethod
     def _get_time_doubles(times):
@@ -1231,16 +1227,14 @@ class Index:
                 return -1
 
             if self.interleaved:
-                coordinates = Index.deinterleave(coordinates)
+                mins[:] = coordinates[:dimension]
+                maxs[:] = coordinates[dimension:]
+            else:
+                mins[:] = coordinates[::2]
+                maxs[:] = coordinates[1::2]
 
-            # this code assumes the coords are not interleaved.
-            # xmin, xmax, ymin, ymax, zmin, zmax
-            for i in range(dimension):
-                mins[i] = coordinates[i * 2]
-                maxs[i] = coordinates[(i * 2) + 1]
-
-            p_mins[0] = ctypes.cast(mins, ctypes.POINTER(ctypes.c_double))
-            p_maxs[0] = ctypes.cast(maxs, ctypes.POINTER(ctypes.c_double))
+            p_mins[0] = mins
+            p_maxs[0] = maxs
 
             # set the dimension
             p_dimension[0] = dimension
@@ -1510,9 +1504,14 @@ class Property:
         return pprint.pformat(self.as_dict())
 
     def get_index_type(self) -> int:
-        return core.rt.IndexProperty_GetIndexType(self.handle)
+        try:
+            return self._type
+        except AttributeError:
+            self._type = type = core.rt.IndexProperty_GetIndexType(self.handle)
+            return type
 
     def set_index_type(self, value: int) -> None:
+        self._type = value
         return core.rt.IndexProperty_SetIndexType(self.handle, value)
 
     type = property(get_index_type, set_index_type)
@@ -1531,11 +1530,17 @@ class Property:
     :data:`RT_Linear`, :data:`RT_Quadratic`, and :data:`RT_Star`"""
 
     def get_dimension(self) -> int:
-        return core.rt.IndexProperty_GetDimension(self.handle)
+        try:
+            return self._dimension
+        except AttributeError:
+            dim = core.rt.IndexProperty_GetDimension(self.handle)
+            self._dimension = dim
+            return dim
 
     def set_dimension(self, value: int) -> None:
         if value <= 0:
             raise RTreeError("Negative or 0 dimensional indexes are not allowed")
+        self._dimension = value
         return core.rt.IndexProperty_SetDimension(self.handle, value)
 
     dimension = property(get_dimension, set_dimension)

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -207,20 +207,26 @@ class Index:
         self.interleaved = bool(kwargs.get("interleaved", True))
 
         stream = None
+        arrays = None
         basename = None
         storage = None
         if args:
             if isinstance(args[0], str) or isinstance(args[0], bytes):
                 # they sent in a filename
                 basename = args[0]
-                # they sent in a filename, stream
+                # they sent in a filename, stream or filename, buffers
                 if len(args) > 1:
-                    stream = args[1]
+                    if isinstance(args[1], tuple):
+                        arrays = args[1]
+                    else:
+                        stream = args[1]
             elif isinstance(args[0], ICustomStorage):
                 storage = args[0]
                 # they sent in a storage, stream
                 if len(args) > 1:
                     stream = args[1]
+            elif isinstance(args[0], tuple):
+                arrays = args[0]
             else:
                 stream = args[0]
 
@@ -274,11 +280,23 @@ class Index:
             self.handle = self._create_idx_from_stream(stream)
             if self._exception:
                 raise self._exception
+        elif arrays and self.properties.type == RT_RTree:
+            self._exception = None
+
+            try:
+                self.handle = self._create_idx_from_array(*arrays)
+            except AttributeError:
+                raise NotImplementedError("libspatialindex >= 2.1 needed for bulk insert")
+
+            if self._exception:
+                raise self._exception
         else:
             self.handle = IndexHandle(self.properties.handle)
             if stream:  # Bulk insert not supported, so add one by one
                 for item in stream:
                     self.insert(*item)
+            elif arrays:
+                raise NotImplementedError("Bulk insert only supported for RTrees")
 
     def get_size(self) -> int:
         warnings.warn(
@@ -1250,6 +1268,28 @@ class Index:
         stream = core.NEXTFUNC(py_next_item)
         return IndexStreamHandle(self.properties.handle, stream)
 
+    def _create_idx_from_array(self, ibuf, minbuf, maxbuf):
+        assert len(ibuf) == len(minbuf)
+        assert len(ibuf) == len(maxbuf)
+        assert minbuf.strides == maxbuf.strides
+
+        # Cast
+        ibuf = ibuf.astype(int)
+        minbuf = minbuf.astype(float)
+        maxbuf = maxbuf.astype(float)
+
+        # Extract counts
+        n, d = minbuf.shape
+
+        # Compute strides
+        i_stri = ibuf.strides[0] // 8
+        d_i_stri = minbuf.strides[0] // 8
+        d_j_stri = minbuf.strides[1] // 8
+
+        return IndexArrayHandle(self.properties.handle, n, d, i_stri,
+                                d_i_stri, d_j_stri, ibuf.ctypes.data,
+                                minbuf.ctypes.data, maxbuf.ctypes.data)
+
     def leaves(self):
         leaf_node_count = ctypes.c_uint32()
         p_leafsizes = ctypes.pointer(ctypes.c_uint32())
@@ -1429,6 +1469,10 @@ class IndexHandle(Handle):
 
 class IndexStreamHandle(IndexHandle):
     _create = core.rt.Index_CreateWithStream
+
+
+class IndexArrayHandle(IndexHandle):
+    _create = core.rt.Index_CreateWithArray
 
 
 class PropertyHandle(Handle):

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -286,7 +286,9 @@ class Index:
             try:
                 self.handle = self._create_idx_from_array(*arrays)
             except AttributeError:
-                raise NotImplementedError("libspatialindex >= 2.1 needed for bulk insert")
+                raise NotImplementedError(
+                    "libspatialindex >= 2.1 needed for bulk insert"
+                )
 
             if self._exception:
                 raise self._exception
@@ -1286,9 +1288,17 @@ class Index:
         d_i_stri = minbuf.strides[0] // 8
         d_j_stri = minbuf.strides[1] // 8
 
-        return IndexArrayHandle(self.properties.handle, n, d, i_stri,
-                                d_i_stri, d_j_stri, ibuf.ctypes.data,
-                                minbuf.ctypes.data, maxbuf.ctypes.data)
+        return IndexArrayHandle(
+            self.properties.handle,
+            n,
+            d,
+            i_stri,
+            d_i_stri,
+            d_j_stri,
+            ibuf.ctypes.data,
+            minbuf.ctypes.data,
+            maxbuf.ctypes.data,
+        )
 
     def leaves(self):
         leaf_node_count = ctypes.c_uint32()


### PR DESCRIPTION
At the moment attempting to do something like:
```
props = Property(dimension=3, index_capacity=25, leaf_capacity=25)
idx = Index([], properties=props)
```
will throw an exception because the near minimum overlap factor is greater than the leaf/index capacities.  Interestingly (and for reasons I can not understand) it does not throw an exception if `[]` is replaced by actual entries.  It is only an issue for an initially empty index.

Either way, this PR adds some consistency checks so everything works as expected.