### PR TITLE
rtree.index.Index: avoid use of args/kwargs

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 import rtree
 from rtree import Rtree as _Rtree
+from rtree.index import Property
 
 print(f"Benchmarking Rtree-{rtree.__version__} from {Path(rtree.__file__).parent}")
 print(f"Using {rtree.core.rt._name} version {rtree.core.rt.SIDX_Version().decode()}")
@@ -66,7 +67,7 @@ insert_object = {
 }
 
 index = Rtree()
-disk_index = Rtree("test", overwrite=1)
+disk_index = Rtree("test", properties=Property(overwrite=1))
 
 coordinates = []
 random.seed("Rtree", version=2)

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -7,7 +7,7 @@ import pickle
 import pprint
 import warnings
 from collections.abc import Iterator, Sequence
-from typing import Any, Generator, Literal, overload
+from typing import Any, Literal, overload
 
 from . import core
 from .exceptions import RTreeError
@@ -196,7 +196,6 @@ class Index:
             raise RuntimeError(
                 "TPR-Tree type not supported with version of libspatialindex"
             )
-
 
         if filename:
             self.properties.storage = RT_Disk

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -80,6 +80,7 @@ class Index:
 
     def __init__(
         self,
+        *args: Any,
         filename: str | bytes | None = None,
         stream: Any | None = None,
         storage: ICustomStorage | None = None,
@@ -89,10 +90,10 @@ class Index:
     ) -> None:
         """Creates a new index
 
-        :param filename: a filename determining that a file-based storage for the index
+        :param filename: A filename determining that a file-based storage for the index
             should be used.
 
-        :param stream: an iterable stream of data that will raise a StopIteration.
+        :param stream: An iterable stream of data that will raise a StopIteration.
             It must be in the form defined by the :attr:`interleaved` attribute of the
             index. The following example would assume :attr:`interleaved` is False::
 
@@ -196,6 +197,29 @@ class Index:
             raise RuntimeError(
                 "TPR-Tree type not supported with version of libspatialindex"
             )
+
+        if args:
+            msg = "Index() parameters without keyword arguments are deprecated"
+            warnings.warn(msg, DeprecationWarning)
+
+            if isinstance(args[0], str) or isinstance(args[0], bytes):
+                # they sent in a filename
+                filename = args[0]
+                # they sent in a filename, stream or filename, buffers
+                if len(args) > 1:
+                    if isinstance(args[1], tuple):
+                        arrays = args[1]
+                    else:
+                        stream = args[1]
+            elif isinstance(args[0], ICustomStorage):
+                storage = args[0]
+                # they sent in a storage, stream
+                if len(args) > 1:
+                    stream = args[1]
+            elif isinstance(args[0], tuple):
+                arrays = args[0]
+            else:
+                stream = args[0]
 
         if filename:
             self.properties.storage = RT_Disk

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -240,7 +240,7 @@ class IndexIntersection(IndexTestCase):
         self.assertTrue(0 in self.idx.intersection((0, 0, 60, 60)))
         hits = list(self.idx.intersection((0, 0, 60, 60)))
 
-        self.assertTrue(len(hits), 10)
+        self.assertEqual(len(hits), 10)
         self.assertEqual(hits, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
 
     def test_objects(self) -> None:
@@ -436,14 +436,14 @@ class IndexSerialization(unittest.TestCase):
             idx.add(i, coords)
 
         hits = list(idx.intersection((0, 0, 60, 60)))
-        self.assertTrue(len(hits), 10)
+        self.assertEqual(len(hits), 10)
         self.assertEqual(hits, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
         del idx
 
         # Check we can reopen the index and get the same results
         idx2 = index.Index(tname, properties=p)
         hits = list(idx2.intersection((0, 0, 60, 60)))
-        self.assertTrue(len(hits), 10)
+        self.assertEqual(len(hits), 10)
         self.assertEqual(hits, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
 
     @pytest.mark.skipif(not sys.maxsize > 2**32, reason="Fails on 32bit systems")
@@ -465,7 +465,7 @@ class IndexSerialization(unittest.TestCase):
             tname, data_gen(interleaved=False), properties=p, interleaved=False
         )
         hits1 = sorted(list(idx.intersection((0, 60, 0, 60))))
-        self.assertTrue(len(hits1), 10)
+        self.assertEqual(len(hits1), 10)
         self.assertEqual(hits1, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
 
         leaves = idx.leaves()
@@ -591,7 +591,7 @@ class IndexSerialization(unittest.TestCase):
         )
 
         hits2 = sorted(list(idx.intersection((0, 60, 0, 60), objects=True)))
-        self.assertTrue(len(hits2), 10)
+        self.assertEqual(len(hits2), 10)
         self.assertEqual(hits2[0].object, 42)
 
     def test_overwrite(self) -> None:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -36,7 +36,7 @@ class IndexTestCase(unittest.TestCase):
         # some versions of libspatialindex screw up indexes on stream loading
         # so do a very simple index check
         rtree_test = rtree.index.Index(
-            [(1564, [0, 0, 0, 10, 10, 10], None)],
+            stream=[(1564, [0, 0, 0, 10, 10, 10], None)],
             properties=rtree.index.Property(dimension=3),
         )
         assert next(rtree_test.intersection([1, 1, 1, 2, 2, 2])) == 1564
@@ -600,7 +600,7 @@ class IndexSerialization(unittest.TestCase):
 
         idx = index.Index(tname)
         del idx
-        idx = index.Index(tname, overwrite=True)
+        idx = index.Index(tname, properties=index.Property(overwrite=True))
         assert isinstance(idx, index.Index)
 
 
@@ -700,7 +700,7 @@ class IndexMoreDimensions(IndexTestCase):
 class IndexStream(IndexTestCase):
     def test_stream_input(self) -> None:
         p = index.Property()
-        sindex = index.Index(self.boxes15_stream(), properties=p)
+        sindex = index.Index(stream=self.boxes15_stream(), properties=p)
         bounds = (0, 0, 60, 60)
         hits = sindex.intersection(bounds)
         self.assertEqual(sorted(hits), [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
@@ -726,7 +726,7 @@ class IndexStream(IndexTestCase):
                     yield (i, (1, 2, 3, 4), None)
                 raise TestException("raising here")
 
-            return index.Index(gen())
+            return index.Index(stream=gen())
 
         self.assertRaises(TestException, create_index)
 
@@ -810,7 +810,7 @@ class IndexCustomStorage(unittest.TestCase):
         # we just use it here for illustrative and testing purposes.
 
         storage = DictStorage()
-        r = index.Index(storage, properties=settings)
+        r = index.Index(storage=storage, properties=settings)
 
         # Interestingly enough, if we take a look at the contents of our
         # storage now, we can see the Rtree has already written two pages
@@ -849,12 +849,13 @@ class IndexCustomStorage(unittest.TestCase):
         settings = index.Property()
         settings.writethrough = True
         settings.buffering_capacity = 1
+        settings.overwrite = True
 
-        r1 = index.Index(storage, properties=settings, overwrite=True)
+        r1 = index.Index(storage=storage, properties=settings)
         r1.add(555, (2, 2))
         del r1
         self.assertTrue(storage.hasData)
 
-        r2 = index.Index(storage, properly=settings, overwrite=False)
+        r2 = index.Index(storage=storage, properties=settings)
         count = r2.count((0, 0, 10, 10))
         self.assertEqual(count, 1)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -711,7 +711,8 @@ class IndexStream(IndexTestCase):
 
     def test_empty_stream(self) -> None:
         """Assert empty stream raises exception"""
-        self.assertRaises(RTreeError, index.Index, iter(()))
+        with self.assertRaises(RTreeError):
+            index.Index(stream=iter(()))
 
     def test_exception_in_generator(self) -> None:
         """Assert exceptions raised in callbacks are raised in main thread"""
@@ -856,6 +857,7 @@ class IndexCustomStorage(unittest.TestCase):
         del r1
         self.assertTrue(storage.hasData)
 
+        settings.overwrite = False
         r2 = index.Index(storage=storage, properties=settings)
         count = r2.count((0, 0, 10, 10))
         self.assertEqual(count, 1)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -400,7 +400,7 @@ class IndexSerialization(unittest.TestCase):
         """Unicode filenames work as expected"""
         tname = tempfile.mktemp()
         filename = tname + "gilename\u4500abc"
-        idx = index.Index(filename)
+        idx = index.Index(filename=filename)
         idx.insert(
             4321, (34.3776829412, 26.7375853734, 49.3776829412, 41.7375853734), obj=42
         )
@@ -431,7 +431,7 @@ class IndexSerialization(unittest.TestCase):
         p.dat_extension = "data"
         p.idx_extension = "index"
         tname = tempfile.mktemp()
-        idx = index.Index(tname, properties=p)
+        idx = index.Index(filename=tname, properties=p)
         for i, coords in enumerate(self.boxes15):
             idx.add(i, coords)
 
@@ -441,7 +441,7 @@ class IndexSerialization(unittest.TestCase):
         del idx
 
         # Check we can reopen the index and get the same results
-        idx2 = index.Index(tname, properties=p)
+        idx2 = index.Index(filename=tname, properties=p)
         hits = list(idx2.intersection((0, 0, 60, 60)))
         self.assertEqual(len(hits), 10)
         self.assertEqual(hits, [0, 4, 16, 27, 35, 40, 47, 50, 76, 80])
@@ -462,7 +462,10 @@ class IndexSerialization(unittest.TestCase):
         p = index.Property()
         tname = tempfile.mktemp()
         idx = index.Index(
-            tname, data_gen(interleaved=False), properties=p, interleaved=False
+            filename=tname,
+            stream=data_gen(interleaved=False),
+            properties=p,
+            interleaved=False,
         )
         hits1 = sorted(list(idx.intersection((0, 60, 0, 60))))
         self.assertEqual(len(hits1), 10)
@@ -598,9 +601,9 @@ class IndexSerialization(unittest.TestCase):
         """Index overwrite works as expected"""
         tname = tempfile.mktemp()
 
-        idx = index.Index(tname)
+        idx = index.Index(filename=tname)
         del idx
-        idx = index.Index(tname, properties=index.Property(overwrite=True))
+        idx = index.Index(filename=tname, properties=index.Property(overwrite=True))
         assert isinstance(idx, index.Index)
 
 
@@ -744,7 +747,7 @@ class IndexStream(IndexTestCase):
             def gen() -> None:
                 raise TestException("raising here")
 
-            return index.Index(gen())  # type: ignore[func-returns-value]
+            return index.Index(stream=gen())  # type: ignore[func-returns-value]
 
         self.assertRaises(TestException, create_index)
 


### PR DESCRIPTION
I spent longer than I would have liked trying to figure out why:
```python
index = Index(properties=Property(dimension=3, interleaved=False))
```
wasn't working. If we weren't using `*args, **kwargs` everywhere, I would have immediately figured this out. This PR starts with `Index`, but eventually I plan to move to other classes as well.

`*args, **kwargs` should be avoided for the following reasons:

* Does not report an issue when unknown kwargs are used (my problem)
* Does not report an issue when misspelled kwargs are used (actually discovered this in the tests)
* Does not support type hints

Basically the only time to use `*args, **kwargs` is when you have one function that wraps around another function and you need to pass through all arguments.

At the moment, this change is backwards incompatible since I replace `*args` with individual parameters and remove support for additional `Property` passthroughs. I could undo this change if we want to only remove `**kwargs` and keep things backwards compatible.