### PR TITLE
Rename project to lowercase "rtree"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Rtree.egg-info/
+*.egg-info/
 *.pyc
 docs/build
 build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "Rtree"
+name = "rtree"
 authors = [
     {name = "Sean Gillies", email = "sean.gillies@gmail.com"},
 ]

--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -77,7 +77,7 @@ def load() -> ctypes.CDLL:
                 if pkg_files is not None:
                     for file in pkg_files:  # type: ignore
                         if (
-                            file.parent.name == "Rtree.libs"
+                            file.parent.name == "rtree.libs"
                             and file.stem.startswith("libspatialindex")
                             and ".so" in file.suffixes
                         ):

--- a/scripts/repair_wheel.py
+++ b/scripts/repair_wheel.py
@@ -45,7 +45,7 @@ def main():
         # use the platform specific repair tool first
         if os_ == "linux":
             # use path from cibuildwheel which allows auditwheel to create
-            # Rtree.libs/libspatialindex-*.so.*
+            # rtree.libs/libspatialindex-*.so.*
             cibw_lib_path = "/project/rtree/lib"
             if os.environ.get("LD_LIBRARY_PATH"):  # append path
                 os.environ["LD_LIBRARY_PATH"] += f"{os.pathsep}{cibw_lib_path}"
@@ -96,7 +96,7 @@ def main():
 
         if os_ == "linux":
             # This is auditwheel's libs, which needs post-processing
-            libs_dir = unpackdir / "Rtree.libs"
+            libs_dir = unpackdir / "rtree.libs"
             lsidx_list = list(libs_dir.glob("libspatialindex*.so*"))
             assert len(lsidx_list) == 1, list(libs_dir.iterdir())
             lsidx = lsidx_list[0]


### PR DESCRIPTION
This renames the project name from "Rtree" to "rtree", which resolves tools that assume lowercase names.  Just looking at the build tools like setuptools and cibuildwheel, I'm noticing that they are less forgiving for projects with mixed-case project names.

For example, I've looked over the PyPI archives, up to [version 0.8.3](https://pypi.org/project/Rtree/0.8.3/#files) (Dec 15, 2016) the sdist and bdist files are consistently `Rtree*`. However, since [version 0.9.1](https://pypi.org/project/Rtree/0.9.1/#files) (Nov 26, 2019) the files are either `Rtree-*.tar.gz` sdist or `rtree-*.whl` bdist files. And now recent cibuildwheel and/or auditwheel tools assume lowercase projects, and don't work anymore (#349).

This change would make sdist and bdist files (e.g. for PyPI) consistently `rtree-*{.whl|.tar.gz}`, and the included bdist libraries for Linux would be in `rtree.libs`. It should also fix recent issues with cibuildwheel and/or auditwheel.