### PR TITLE
CI: use ubuntu-24.04-arm instead of QEMU to build ARM-based wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,16 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, ubuntu-24.04-arm, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Set up QEMU
-      if: runner.os == 'Linux'
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: arm64
 
     - uses: actions/setup-python@v5
       name: Install Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,11 @@ repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"
 test-command = "tox --conf {project} --installpkg {wheel}"
 test-skip = [
-    "*aarch64",  # slow!
     "*-macosx_arm64",
 ]
 
 [tool.cibuildwheel.linux]
-archs = ["auto", "aarch64"]
+archs = ["auto"]
 before-build = [
     "yum install -y cmake libffi-devel",
     "sh {project}/scripts/install_libspatialindex.sh",


### PR DESCRIPTION
Details of this image are [here](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md). It should make building and testing Linux ARM wheels much quicker.