### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,20 +8,20 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 0.31.2
     hooks:
     - id: check-github-workflows
       args: ["--verbose"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.9
     hooks:
-    # Run the linter.
+    # Run the linter
     - id: ruff
       args: [ --fix ]
-    # Run the formatter.
+    # Run the formatter
     - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
     - id: mypy
       exclude: 'docs/.'

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -164,7 +164,7 @@ hits = disk_index.intersection(bbox, objects="raw")
     t = timeit.Timer(
         stmt=s, setup="from __main__ import points, disk_index, bbox, insert_object"
     )
-    print("Disk-based Rtree Intersection " "without Item() wrapper (objects='raw'):")
+    print("Disk-based Rtree Intersection without Item() wrapper (objects='raw'):")
     result = list(disk_index.intersection(bbox, objects="raw"))
     print(len(result), "raw hits")
     print(f"{1e6 * t.timeit(number=TEST_TIMES) / TEST_TIMES:.2f} usec/pass")


### PR DESCRIPTION
This update really only has one change from `ruff format` with an improvement in `benchmarks/benchmarks.py`.