### PR TITLE
Update testing to libspatialindex-2.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-        # test oldest and newest libspatialindex versions
-        sidx-version: ['1.8.5', '2.0.0']
+        # test oldest and newest versions of python and libspatialindex
+        python-version: ['3.9', '3.13']
+        sidx-version: ['1.8.5', '2.1.0']
         exclude:
           - os: 'macos-latest'
           - sidx-version: '1.8.5'

--- a/scripts/install_libspatialindex.bat
+++ b/scripts/install_libspatialindex.bat
@@ -1,6 +1,6 @@
 python -c "import sys; print(sys.version)"
 
-set SIDX_VERSION=2.0.0
+set SIDX_VERSION=2.1.0
 
 curl -LO --retry 5 --retry-max-time 120 "https://github.com/libspatialindex/libspatialindex/archive/%SIDX_VERSION%.zip"
 

--- a/scripts/install_libspatialindex.sh
+++ b/scripts/install_libspatialindex.sh
@@ -2,8 +2,8 @@
 set -xe
 
 # A simple script to install libspatialindex from a Github Release
-VERSION=2.0.0
-SHA256=8caa4564c4592824acbf63a2b883aa2d07e75ccd7e9bf64321c455388a560579
+VERSION=2.1.0
+SHA256=86aa0925dd151ff9501a5965c4f8d7fb3dcd8accdc386a650dbdd62660399926
 
 # where to copy resulting files
 # this has to be run before `cd`-ing anywhere


### PR DESCRIPTION
This updates wheel building and testing to use [libspatialindex-2.1.0](https://github.com/libspatialindex/libspatialindex/releases/tag/2.1.0).