### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.4.0: 2025-03-06
+=================
+
+- Python 3.9+ is now required (:PR:`321`)
+- Add support for array-based bulk insert with NumPy (:PR:`340` by :user:`FreddieWitherden`)
+- Upgrade binary wheels with libspatialindex-2.1.0 (:PR:`353`)
+- Rename project and other build components to "rtree" (:PR:`350`)
+
 1.3.0: 2024-07-10
 =================
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rtree: Spatial indexing for Python
 
 ![Build](https://github.com/Toblerity/rtree/workflows/Build/badge.svg)
-[![PyPI version](https://badge.fury.io/py/Rtree.svg)](https://badge.fury.io/py/Rtree)
+[![PyPI version](https://badge.fury.io/py/rtree.svg)](https://badge.fury.io/py/rtree)
 
 
 Rtree is a [ctypes](https://docs.python.org/3/library/ctypes.html) Python wrapper of [libspatialindex](https://libspatialindex.org/) that provides a

--- a/docs/source/class.rst
+++ b/docs/source/class.rst
@@ -4,7 +4,7 @@ Class Documentation
 ------------------------------------------------------------------------------
 
 .. autoclass:: rtree.index.Index
-    :members: __init__, insert, intersection, nearest, delete, bounds, count, close, dumps, loads
+    :members: __init__, insert, intersection, intersection_v, nearest, nearest_v, delete, bounds, count, close, dumps, loads
 
 .. autoclass:: rtree.index.Property
     :members:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -22,7 +22,7 @@ ensure that applications can find it at startup time.
 
 Rtree can be easily installed via pip::
 
-  $ pip install Rtree
+  $ pip install rtree
 
 or by running in a local source directory::
 
@@ -39,8 +39,8 @@ The Windows DLLs of `libspatialindex`_ are pre-compiled in
 windows installers that are available from `PyPI`_.  Installation on Windows
 is as easy as::
 
-  pip install Rtree
+  pip install rtree
 
 
-.. _`PyPI`: https://pypi.org/project/Rtree/
+.. _`PyPI`: https://pypi.org/project/rtree/
 .. _`libspatialindex`: https://libspatialindex.org

--- a/rtree/__init__.py
+++ b/rtree/__init__.py
@@ -7,6 +7,6 @@ hyperrectangular intersection queries.
 
 from __future__ import annotations
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 from .index import Index, Rtree  # noqa

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class InstallPlatlib(install):  # type: ignore[misc]
 
 # See pyproject.toml for other project metadata
 setup(
-    name="Rtree",
+    name="rtree",
     distclass=BinaryDistribution,
     cmdclass={"bdist_wheel": bdist_wheel, "install": InstallPlatlib},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,11 @@ import os
 import shutil
 from collections.abc import Iterator
 
+import numpy
 import py
 import pytest
+
+import rtree
 
 data_files = ["boxes_15x15.data"]
 
@@ -17,3 +20,12 @@ def temporary_working_directory(tmpdir: py.path.local) -> Iterator[None]:
         shutil.copy(filename, str(tmpdir))
     with tmpdir.as_cwd():
         yield
+
+
+def pytest_report_header(config):
+    """Header for pytest."""
+    vers = [
+        f"SIDX version: {rtree.core.rt.SIDX_Version().decode()}",
+        f"NumPy version: {numpy.__version__}",
+    ]
+    return "\n".join(vers)


### PR DESCRIPTION
This contains release notes for v1.4.0. It also has a "last minute" update to the pytest report header to show the version of NumPy and libspatialindex.

Closes #348