### PR TITLE
Fixing an incorrect reassignment in nearest_v and intersection_v

### DIFF
--- a/rtree/index.py
+++ b/rtree/index.py
@@ -1103,7 +1103,7 @@ class Index:
                 offi += counts[offn : offn + nr.value].sum()
                 offn += nr.value
 
-                ids = ids.resize(2 * len(ids), refcheck=False)
+                ids.resize(2 * len(ids), refcheck=False)
 
     def nearest_v(
         self,
@@ -1200,7 +1200,7 @@ class Index:
                 offi += counts[offn : offn + nr.value].sum()
                 offn += nr.value
 
-                ids = ids.resize(2 * len(ids), refcheck=False)
+                ids.resize(2 * len(ids), refcheck=False)
 
     def _nearestTP(self, coordinates, velocities, times, num_results=1, objects=False):
         p_mins, p_maxs = self.get_coordinate_pointers(coordinates)


### PR DESCRIPTION
The existing implementation confuses `numpy.resize` that returns a new resized array, with `numpy.ndarray.resize` that resizes the array in-place and returns None. Relevant numpy documentation:

https://numpy.org/doc/stable/reference/generated/numpy.resize.html
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.resize.html

This causes calls to nearest_v and intersection_v to fail in cases where `nr.value == n - offn` evaluates to false.