### PR TITLE
Add spatialindex version to tests, add common pytest configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Build and upload to PyPI
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - '.github/workflows/deploy.yml'
   push:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   conda:
-    name: Conda ${{ matrix.python-version }} - ${{ matrix.os }}
+    name: Conda Python ${{ matrix.python-version }}, SIDX-${{ matrix.sidx-version }}, ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         sidx-version: ['1.8.5', '2.1.0']
         exclude:
           - os: 'macos-latest'
-          - sidx-version: '1.8.5'
+            sidx-version: '1.8.5'
 
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup
-      run: conda install -c conda-forge numpy pytest libspatialindex=${{ matrix.sidx-version }} -y
+      run: conda install -c conda-forge pip numpy pytest libspatialindex=${{ matrix.sidx-version }} -y
 
     - name: Install
       run: pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ exclude_lines = [
     "@overload",
 ]
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--import-mode=importlib"
+testpaths = ["tests"]
+
 [tool.ruff.lint]
 select = [
     "E", "W",  # pycodestyle

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,6 @@
+"""Common test functions."""
+
+from rtree.core import rt
+
+sidx_version_string = rt.SIDX_Version().decode()
+sidx_version = tuple(map(int, sidx_version_string.split(".", maxsplit=3)[:3]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import numpy
 import py
 import pytest
 
-import rtree
+from .common import sidx_version_string
 
 data_files = ["boxes_15x15.data"]
 
@@ -25,7 +25,7 @@ def temporary_working_directory(tmpdir: py.path.local) -> Iterator[None]:
 def pytest_report_header(config):
     """Header for pytest."""
     vers = [
-        f"SIDX version: {rtree.core.rt.SIDX_Version().decode()}",
+        f"SIDX version: {sidx_version_string}",
         f"NumPy version: {numpy.__version__}",
     ]
     return "\n".join(vers)

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,4 @@ install_command =
     python -I -m pip install --only-binary=:all: {opts} {packages}
 ignore_errors = True
 ignore_outcome = True
-commands =
-    pytest --import-mode=importlib {posargs:tests}
+commands = pytest


### PR DESCRIPTION
This adds a `common` module for the tests, for items that aren't fixtures. So far it gets the libspatialindex version string and tuple.

Also establish a pytest configuration.