### PR TITLE
fix #369 (load libspatialindex without changing cwd)

### DIFF
--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -105,7 +105,7 @@ def load() -> ctypes.CDLL:
                 # try loading the target file candidate
                 # These should be fully specified paths to
                 # files
-                rt = ctypes.cdll.LoadLibrary(target)
+                rt = ctypes.cdll.LoadLibrary(str(target))
                 if rt is not None:
                     return rt
             except BaseException as err:


### PR DESCRIPTION
# Changes

- Avoid changing directory to load the `libspatialindex` library candidate (fix #369)
