### PR TITLE
Adjust CI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      attestations: write
     steps:
       - run: echo 'The wheels workflow succeeded and uploaded artifacts'
       - uses: actions/download-artifact@v4
@@ -21,6 +22,9 @@ jobs:
           pattern: cibw-*
           path: dist
           merge-multiple: true
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'dist/**/*'
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,11 @@
-name: Build and upload to PyPI
+name: PyPI Push
 
 on:
+  workflow_run:
+    workflows: [Wheels]
+    types:
+      - completed
+
   workflow_dispatch:
   pull_request:
     paths:
@@ -15,52 +20,8 @@ on:
       - published
 
 jobs:
-  build_wheels:
-    name: Build wheel on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - windows-latest
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-          - macos-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - uses: actions/setup-python@v5
-      name: Install Python
-      with:
-        python-version: '3.11'
-
-    - uses: ilammy/msvc-dev-cmd@v1
-      if: startsWith(matrix.os, 'windows')
-
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v3.1.1
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cibw-wheels-${{ matrix.os }}
-        path: ./wheelhouse/*.whl
-
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Build sdist
-      run: pipx run build --sdist
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cibw-sdist
-        path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,32 +6,26 @@ on:
     types:
       - completed
 
-  workflow_dispatch:
-  pull_request:
-    paths:
-      - '.github/workflows/deploy.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/deploy.yml'
-  release:
-    types:
-      - published
-
 jobs:
 
-  upload_pypi:
+  on-success:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: pypi
     permissions:
       id-token: write
-    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: cibw-*
-        path: dist
-        merge-multiple: true
+      - run: echo 'The wheels workflow succeeded and uploaded artifacts'
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release' && github.event.action == 'published'
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The Wheels workflow failed so we cannot push to PyPI'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,52 @@
+name: Wheels
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build_wheels:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      name: Install Python
+      with:
+        python-version: '3.13'
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: startsWith(matrix.os, 'windows')
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v3.1.3
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: cibw-wheels-${{ matrix.os }}
+        path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build sdist
+      run: pipx run build --sdist
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: cibw-sdist
+        path: dist/*.tar.gz
+


### PR DESCRIPTION
* Always build Wheels for every branch/push so we know if they're failing
* Make the PyPI Push dispatch contingent on Wheels succeeding
* Add [attestments](https://github.com/actions/attest-build-provenance) to the artifacts
* bump cibuildwheel to `pypa/cibuildwheel@v3.1.3`