### PR TITLE
CI: use brew bundle to avoid non-zero exit on existing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,9 @@ before-build = [
 archs = ["x86_64", "arm64"]
 environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
 before-build = [
-    "brew install coreutils cmake",
+    "brew bundle add cmake",
+    "brew bundle add coreutils",
+    "brew bundle install",
     "sh {project}/scripts/install_libspatialindex.sh",
 ]
 


### PR DESCRIPTION
It appears that `brew install <pkg>` will exit with non-zero if the package and version match is already installed. It will exit with zero if the package is installed, but the version needs to be upgraded. This gets annoying for [these lines](https://github.com/Toblerity/rtree/blob/2299d2080a1aad05ba9a1be03d130dff6f6ee4cd/pyproject.toml#L78-L79) used for cibuildwheel.

Lets try to use the brew bundle concept instead. By default `brew bundle install` will upgrade (if needed) but otherwise not return non-zero exit if it already exists.