### PR TITLE
Test with Python 3.14 as upper version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         # test oldest and newest versions of python and libspatialindex
-        python-version: ['3.9', '3.13']
+        python-version: ['3.9', '3.14']
         sidx-version: ['1.8.5', '2.1.0']
         exclude:
           - os: 'macos-latest'
@@ -58,7 +58,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # test oldest and newest versions of python
+        python-version: ['3.9', '3.14']
 
     steps:
     - uses: actions/checkout@v5
@@ -104,7 +105,7 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.13'
+        python-version: '3.x'
 
     - uses: ilammy/msvc-dev-cmd@v1.13.0
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Database",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{39,310,311,312,313}
+env_list = py{39,310,311,312,313,314}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
Start testing with Python 3.14, expected in October 2025 ([PEP 745](https://peps.python.org/pep-0745/)).

The `ubuntu` CI jobs can be pruned down to the upper and lower Python version with no loss of coverage. Full range of Python versions are tested by cibuildwheel with tox.

Also add a new classifier. (Although, I could also be convinced to remove most of these classifiers, as they are not always relevant, i.e. previous releases on PyPI could usually work with with future versions of Python).