### PR TITLE
fix: add fallback for finding bundled library when importlib.metadata unavailable

### DIFF
--- a/rtree/finder.py
+++ b/rtree/finder.py
@@ -86,6 +86,14 @@ def load() -> ctypes.CDLL:
             except importlib.metadata.PackageNotFoundError:
                 pass
 
+            # Fallback: search relative to package directory
+            # (works when importlib.metadata is unavailable, e.g. Bazel, some venvs)
+            libs_dir = _cwd.parent / "rtree.libs"
+            if libs_dir.exists():
+                for so_file in libs_dir.glob("libspatialindex*.so"):
+                    _candidates.insert(1, so_file)
+                    break
+
         for cand in _candidates:
             if cand.is_dir():
                 # if our candidate is a directory use best guess

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -1,4 +1,3 @@
-import sys
 from ctypes import CDLL
 from pathlib import Path
 from unittest import mock

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -1,5 +1,7 @@
+import sys
 from ctypes import CDLL
 from pathlib import Path
+from unittest import mock
 
 from rtree import finder
 
@@ -7,6 +9,22 @@ from rtree import finder
 def test_load():
     lib = finder.load()
     assert isinstance(lib, CDLL)
+
+
+def test_load_without_importlib_metadata():
+    """Test that library loading works when importlib.metadata.files() is unavailable.
+
+    This can happen in sandboxed environments like Bazel where package metadata
+    isn't properly exposed.
+    """
+    # Reload finder module with mocked importlib.metadata.files returning None
+    with mock.patch("importlib.metadata.files", return_value=None):
+        # Need to reload the module to re-run the load logic
+        import importlib
+
+        importlib.reload(finder)
+        lib = finder.load()
+        assert isinstance(lib, CDLL)
 
 
 def test_get_include():


### PR DESCRIPTION
## Summary

When running in sandboxed environments like Bazel (with `rules_python`), `importlib.metadata.files()` may return `None` or fail to locate files correctly, even though the bundled `libspatialindex` library exists in the wheel.

This PR adds a fallback that searches for the bundled library relative to the package directory (`rtree.libs/`), which works regardless of metadata availability.

## Problem

In Bazel's sandboxed test environment:
```
OSError: Could not load libspatialindex_c library
```

The library exists at `rtree.libs/libspatialindex-*.so` but `importlib.metadata.files("rtree")` returns `None` because Bazel doesn't properly expose package metadata.

## Solution

After the existing `importlib.metadata` lookup, add a simple fallback:
```python
libs_dir = _cwd.parent / "rtree.libs"
if libs_dir.exists():
    for so_file in libs_dir.glob("libspatialindex*.so"):
        _candidates.insert(1, so_file)
        break
```

This uses the already-defined `_cwd` (`Path(__file__).parent`) to locate the library relative to the package, which works in any environment.

## Testing

- Added test that mocks `importlib.metadata.files()` returning `None`
- Verified fix works in Bazel environment (commit 1 fails, commit 2 passes)