### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup
-      run: conda install -c conda-forge pip numpy pytest libspatialindex=${{ matrix.sidx-version }} -y
+      run: conda install -c conda-forge pip numpy "pytest<9.1" libspatialindex=${{ matrix.sidx-version }} -y
 
     - name: Install
       run: pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v4.0.0
       env:
-         CIBW_BUILD: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && 'cp311-*' || 'cp39-*' }}
+         CIBW_BUILD: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && 'cp311-*' || 'cp310-*' }}
 
     - uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         # test oldest and newest versions of python and libspatialindex
-        python-version: ['3.9', '3.14']
+        python-version: ['3.10', '3.14']
         sidx-version: ['1.8.5', '2.1.0']
         exclude:
           - os: 'macos-latest'
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         # test all supported minor versions of python
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v7
@@ -73,7 +73,7 @@ jobs:
       run: |
           sudo apt-get -y install libspatialindex-c6
           pip install --upgrade pip
-          pip install numpy pytest
+          pip install numpy "pytest<9.1"
 
     - name: Build
       run: pip install --user .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.3
     hooks:
     - id: check-github-workflows
       args: ["--verbose"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.18
     hooks:
     # Run the linter
     - id: ruff-check
@@ -21,7 +21,7 @@ repos:
     # Run the formatter
     - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.0
+    rev: v2.1.0
     hooks:
     - id: mypy
       exclude: 'docs/.'

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -1,4 +1,4 @@
-- python 3.9+
+- python 3.10+
 - setuptools
 - libspatialindex C library 1.8.5+:
   https://libspatialindex.org/

--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,5 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python>=3.9
+- python>=3.10
 - libspatialindex>=1.8.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 ]
 description = "R-Tree spatial index for Python GIS"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["gis", "spatial", "index", "r-tree"]
 license = "MIT"
 classifiers = [
@@ -22,7 +22,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -97,7 +96,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 addopts = "--import-mode=importlib"
 testpaths = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ rtree = ["py.typed"]
 
 [tool.cibuildwheel]
 build-verbosity = 3
-before-all = "pip install wheel"
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"
 test-command = "tox --conf {project} --installpkg {wheel}"
@@ -60,6 +59,7 @@ test-skip = [
 [tool.cibuildwheel.linux]
 archs = ["auto"]
 before-build = [
+    "pip install wheel",
     "yum install -y cmake libffi-devel",
     "sh {project}/scripts/install_libspatialindex.sh",
 ]
@@ -67,6 +67,7 @@ before-build = [
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-build = [
+    "pip install wheel",
     "apk add cmake libffi-dev",
     "sh {project}/scripts/install_libspatialindex.sh",
 ]
@@ -75,6 +76,7 @@ before-build = [
 archs = ["x86_64", "arm64"]
 environment = { MACOSX_DEPLOYMENT_TARGET="10.9" }
 before-build = [
+    "pip install wheel",
     "brew bundle add cmake",
     "brew bundle add coreutils",
     "brew bundle install",
@@ -84,6 +86,7 @@ before-build = [
 [tool.cibuildwheel.windows]
 archs = ["auto64"]
 before-build = [
+    "pip install wheel",
     "call {project}\\scripts\\install_libspatialindex.bat",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from setuptools import setup
 from setuptools.command.install import install
 from setuptools.dist import Distribution
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+try:
+    from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+except ImportError:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 # current working directory of this setup.py file
 _cwd = Path(__file__).resolve().parent

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 requires =
     tox>=4
-env_list = py{39,310,311,312,313,314}
+env_list = py{310,311,312,313,314}
 
 [testenv]
 description = run unit tests
 deps =
-    pytest>=6
+    pytest>=7.0,<9.1
     numpy
 install_command =
     python -I -m pip install --only-binary=:all: {opts} {packages}


### PR DESCRIPTION
Drop support and testing for Python 3.9, which was EOL since 2025-10-31 ([PEP 569](https://peps.python.org/pep-0596/)). The minimum version is now set to Python 3.10 or later.

Version constrains for pytest are adjusted to suit Python 3.10+, with a temporary upper version constraint to be delt with #412.