### PR TITLE
Use PEP-735 for dependency groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup
-      run: conda install -c conda-forge pip numpy "pytest<9.1" libspatialindex=${{ matrix.sidx-version }} -y
+      run: conda install -c conda-forge pip numpy pytest libspatialindex=${{ matrix.sidx-version }} -y
 
     - name: Install
       run: pip install -e .
@@ -70,13 +70,10 @@ jobs:
         allow-prereleases: true
 
     - name: Setup
-      run: |
-          sudo apt-get -y install libspatialindex-c6
-          pip install --upgrade pip
-          pip install numpy "pytest<9.1"
+      run: sudo apt-get -y install libspatialindex-c6
 
-    - name: Build
-      run: pip install --user .
+    - name: Install
+      run: pip install . --group test
 
     - name: Test with pytest
       run: pytest -Werror -v --doctest-modules rtree tests

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ lib
 wheelhouse
 .vscode/
 *venv*
+*.lock

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,10 @@ build:
    os: ubuntu-lts-latest
    tools:
       python: latest
+   jobs:
+      install:
+      - pip install --upgrade pip
+      - pip install --group docs
 
 # Build documentation in the docs/source directory with Sphinx
 sphinx:
@@ -21,8 +25,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF
 formats:
    - pdf
-
-# Declare the Python requirements required to build your docs
-python:
-   install:
-   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-sphinx>=4
-sphinx-issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,22 @@ dynamic = ["version"]
 Documentation = "https://rtree.readthedocs.io"
 Repository = "https://github.com/Toblerity/rtree"
 
+[dependency-groups]
+dev = [
+    "coverage",
+    "pre-commit",
+    "tox>=4.22",
+    {include-group = "test"},
+]
+docs = [
+    "sphinx>=5.0",
+    "sphinx-issues",
+]
+test = [
+    "numpy",
+    "pytest>=7.0",
+]
+
 [tool.setuptools]
 packages = ["rtree"]
 zip-safe = false

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 requires =
-    tox>=4
+    tox>=4.22
 env_list = py{310,311,312,313,314}
 
 [testenv]
 description = run unit tests
-deps =
-    pytest>=7.0,<9.1
-    numpy
+dependency_groups =
+    test
 install_command =
     python -I -m pip install --only-binary=:all: {opts} {packages}
 ignore_errors = True


### PR DESCRIPTION
This implements [PEP 735](https://peps.python.org/pep-0735/) to use dependency groups for "test" and "docs", as well as a new "dev" group.

ReadTheDocs configuration is re-written slightly to use the "docs" dependency group. The requirements file is removed, and minimum sphinx version is increased to 5.0.

Tox is upgraded to >=4.22 to use the `dependency_groups` feature.

The upper limit "<9.1" for pytest is now removed, as it was only temporary.

Lastly, ignore `*.lock` files from (e.g.) [uv](https://docs.astral.sh/uv/) and [pixi](https://prefix.dev/tools/pixi) tools.