### PR TITLE
Add codespell to pre-commit to catch typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,7 @@ repos:
     hooks:
     - id: mypy
       exclude: 'docs/.'
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+    - id: codespell

--- a/rtree/index.py
+++ b/rtree/index.py
@@ -1090,7 +1090,7 @@ class Index:
                 ctypes.byref(nr),
             )
 
-            # If we got the expected nuber of results then return
+            # If we got the expected number of results then return
             if nr.value == n - offn:
                 return ids[: counts.sum()], counts
             # Otherwise, if our array is too small then resize


### PR DESCRIPTION
Use [codespell](https://github.com/codespell-project/codespell) to identify typos.