### PR TITLE
Remove wheel from build-system requirements, require more recent setuptools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       run: sudo apt-get -y install libspatialindex-c6
 
     - name: Install
-      run: pip install . --group test
+      run: pip install . --group tests
 
     - name: Test with pytest
       run: pytest -Werror -v --doctest-modules rtree tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 0.37.4
     hooks:
     - id: check-github-workflows
       args: ["--verbose"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.20
     hooks:
     # Run the linter
     - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -41,13 +41,13 @@ dev = [
     "coverage",
     "pre-commit",
     "tox>=4.22",
-    {include-group = "test"},
+    {include-group = "tests"},
 ]
 docs = [
     "sphinx>=5.0",
     "sphinx-issues",
 ]
-test = [
+tests = [
     "numpy",
     "pytest>=7.0",
 ]
@@ -64,6 +64,7 @@ version = {attr = "rtree.__version__"}
 rtree = ["py.typed"]
 
 [tool.cibuildwheel]
+build = "cp310-*"
 build-verbosity = 3
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-requires = "tox"

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,9 @@
 from pathlib import Path
 
 from setuptools import setup
+from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
 from setuptools.command.install import install
 from setuptools.dist import Distribution
-
-try:
-    from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
-except ImportError:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 # current working directory of this setup.py file
 _cwd = Path(__file__).resolve().parent

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,7 @@ env_list = py{310,311,312,313,314}
 
 [testenv]
 description = run unit tests
-dependency_groups =
-    test
+dependency_groups = tests
 install_command =
     python -I -m pip install --only-binary=:all: {opts} {packages}
 ignore_errors = True


### PR DESCRIPTION
Recent setuptools implements `bdist_wheel`, so the there is no need to require "wheel" for the build system. Specify `setuptools>=77` to parse license metadata for [PEP 639](https://peps.python.org/pep-0639/) implemented with 5c0846c148138bec24753e64946243ed450feb89 ([ref](https://setuptools.pypa.io/en/stable/history.html#v77-0-0)).

Also, a minor re-working of #414 to rename the dependency group "test" to "tests". Why? Slightly more natural, as it matches the directory name "tests" used at the root of this repo.